### PR TITLE
Outgoing queue purge

### DIFF
--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -274,7 +274,7 @@ class Ssm2(object):
         log.info('Found %s messages.' % self._outq.count())
         for msgid in self._outq:
             if not self._outq.lock(msgid):
-                log.warn('Message queue was locked. %s will not be sent.' % msgid)
+                log.warn('Message was locked. %s will not be sent.' % msgid)
                 continue
 
             text = self._outq.get(msgid)
@@ -289,7 +289,8 @@ class Ssm2(object):
 
             self._last_msg = None
             self._outq.remove(msgid)
-        log.info('Tidying message queue.')
+
+        log.info('Tidying message directory.')
         try:
             # Remove empty dirs and unlock msgs older than 5 min (default)
             self._outq.purge()


### PR DESCRIPTION
Purge added to send_all method will tidy up the outgoing queue directory for clients and any of the server's sending processes. Additionally, locked messages will be unlocked if they are older than 5 minutes.

Performance shouldn't be impacted once the purge is regularly running as it doesn't do anything that different to what the dirq module is already doing in terms of filesystem operations.
