### PR TITLE
Stomppy v4

### DIFF
--- a/apel-ssm.spec
+++ b/apel-ssm.spec
@@ -5,14 +5,14 @@
 
 Name:           apel-ssm
 Version:        2.1.3
-Release:        0.1.alpha%{?dist}
+Release:        0.2.alpha1%{?dist}
 Summary:        Secure stomp messenger
 
 Group:          Development/Languages
 License:        ASL 2.0
 URL:            https://wiki.egi.eu/wiki/APEL/SSM
 # Value between %{version} and extension must match "Release" without %{dist}
-Source0:        %{name}-%{version}-0.1.alpha.tar.gz
+Source0:        %{name}-%{version}-0.2.alpha1.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch:      noarch
 
@@ -31,7 +31,7 @@ The SSM is written in python.
 
 %prep
 # Value after %{version} must match "Release" without %{dist}
-%setup -q -n %{name}-%{version}-0.1.alpha
+%setup -q -n %{name}-%{version}-0.2.alpha1
 
 %build
 


### PR DESCRIPTION
Resolves #3.

Main change on line 19, other changes to spec file are there to facilitate the test build.
- Set requirement for stomppy < 4.0.0 in rpmbuild spec file as versions >=
  4.0.0 are currently incompatible with SSM (proplem raised by a SUSE
  user). The versions of stomppy currently available in all the EPEL
  repositories are no greater than 3.1.6.
