### PR TITLE
Reduce logging level for purge OSError

### DIFF
--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -296,7 +296,7 @@ class Ssm2(stomp.ConnectionListener):
             # Remove empty dirs and unlock msgs older than 5 min (default)
             self._outq.purge()
         except OSError, e:
-            log.error('OSError raised while purging message queue: %s' % e)
+            log.warn('OSError raised while purging message queue: %s' % e)
 
     ############################################################################
     # Connection handling methods


### PR DESCRIPTION
Resolves SSM issue that is the same as issue apel/apel#51 for APEL.

See pull request apel/apel#54.
