### PR TITLE
Improving SSM logging

### DIFF
--- a/bin/receiver.py
+++ b/bin/receiver.py
@@ -201,11 +201,11 @@ def main():
             i += 1
 
     except SystemExit, e:
-        log.info('Received the shutdown signal: ' + str(e))
+        log.info('Received the shutdown signal: %s', e)
         ssm.shutdown()
         dc.close()
     except Exception, e:
-        log.error('Unexpected exception: ' + str(e))
+        log.error('Unexpected exception: %s', e)
         log.error('Exception type: %s', e.__class__)
         log.error('The SSM will exit.')
         ssm.shutdown()

--- a/ssm/crypto.py
+++ b/ssm/crypto.py
@@ -173,10 +173,10 @@ def verify(signed_text, capath, check_crl):
     # 'openssl smime' returns "Verification successful" to standard error. We
     # don't want to log this as an error each time, but we do want to see if
     # there's a genuine error.
-    if "Verification successful" not in error:
-        log.warn(error)
-    else:
+    if "Verification successful" in error:
         log.debug(error)
+    else:
+        log.warn(error)
 
     subj = get_certificate_subject(signer)
     return body, subj

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -142,10 +142,10 @@ class Ssm2(stomp.ConnectionListener):
                 return
         except KeyError:
             empaid = 'noid'
-            
-        log.info('Received message: ' + empaid)
+
+        log.info("Received message. ID = %s", empaid)
         raw_msg, signer = self._handle_msg(body)
-        
+
         try:
             if raw_msg is None:  # the message has been rejected
                 if signer is None:  # crypto failed

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -159,11 +159,12 @@ class Ssm2(stomp.ConnectionListener):
                                           'signer': signer,
                                           'empaid': empaid,
                                           'error': err_msg})
-                log.warn("Message moved to reject queue as %s", name)
+                log.info("Message saved to reject queue as %s", name)
             else:  # message verified ok
-                self._inq.add({'body': raw_msg, 
-                               'signer':signer, 
-                               'empaid': headers['empa-id']})
+                name = self._inq.add({'body': raw_msg,
+                                      'signer': signer,
+                                      'empaid': empaid})
+                log.info("Message saved to accept queue as %s", name)
         except OSError, e:
             log.error('Failed to read or write file: %s', e)
         

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -164,7 +164,7 @@ class Ssm2(stomp.ConnectionListener):
                 name = self._inq.add({'body': raw_msg,
                                       'signer': signer,
                                       'empaid': empaid})
-                log.info("Message saved to accept queue as %s", name)
+                log.info("Message saved to incoming queue as %s", name)
         except OSError, e:
             log.error('Failed to read or write file: %s', e)
         

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -127,8 +127,8 @@ class Ssm2(stomp.ConnectionListener):
         '''
         Called by stomppy when a message is sent.
         '''
-        log.debug('Sent message: ' + headers['empa-id'])
-        
+        log.debug('Sent message: %s', headers['empa-id'])
+
     def on_message(self, headers, body):
         '''
         Called by stomppy when a message is received.
@@ -195,7 +195,7 @@ class Ssm2(stomp.ConnectionListener):
         '''
         Called by stomppy when the broker acknowledges receipt of a message.
         '''
-        log.info('Broker received message: ' + headers['receipt-id'])
+        log.info('Broker received message: %s', headers['receipt-id'])
         self._last_msg = headers['receipt-id']
         
     ##########################################################################
@@ -243,7 +243,7 @@ class Ssm2(stomp.ConnectionListener):
         the host cert and key.  If an encryption certificate
         has been supplied, the message will also be encrypted.
         '''
-        log.info('Sending message: ' + msgid)
+        log.info('Sending message: %s', msgid)
         headers = {'destination': self._dest, 'receipt': msgid,
                    'empa-id': msgid}
         


### PR DESCRIPTION
Resolves #23.

## Main Changes

These changes tidy up the log output of SSM, by reducing the amount of uninteresting log entries,  and make it a bit more useful, by specifying the queue location that messages are saved to.

### Mockups

#### Before
```
2015-02-11 08:00:57,585 - ssm.ssm2 - INFO - Received message: 00000000/20150211080307
2015-02-11 08:00:57,642 - ssm.crypto - INFO - Certificate verification: stdin: OK
2015-02-11 08:00:57,653 - ssm.crypto - INFO - Verification successful
2015-02-11 08:00:57,663 - ssm.ssm2 - INFO - Valid signer: /C=OK/O=SomeGrid/O=ABC/CN=arc-ce.grid.abc.de
```
#### After
```
2015-02-11 08:00:57,585 - ssm.ssm2 - INFO - Received message. ID = 00000000/20150211080307
2015-02-11 08:00:57,663 - ssm.ssm2 - INFO - Valid signer: /C=OK/O=SomeGrid/O=ABC/CN=arc-ce.grid.abc.de
2015-02-11 08:00:57,663 - ssm.ssm2 - INFO - Message saved to incoming queue as 0000000f/56ab123456789ec
```

If a message is rejected, you get its location in the reject queue as well as all the usual log output (with some tweaked logging levels).

## Other changes

- Corrected arguments to logging calls. e.g. those in ` bin/receiver.py`.
- Merged info from some log calls into one entry.