### PR TITLE
Activate Travis containerization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,22 +9,21 @@ matrix:
     - python: "3.4"
   fast_finish: true
 
-# command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install:
-  - pip install stomp.py
-  - pip install python-daemon
-  - pip install python-ldap
-  - pip install dirq
-  - pip install unittest2
-  - pip install coveralls
+# Route build to container-based infrastructure
+sudo: false
+# Cache the dependencies installed by pip
+cache: pip
+
+# Install defaults to "pip install -r requirements.txt"
 
 before_script:
   - export TMPDIR=$PWD/tmp
   - mkdir $TMPDIR
-# command to run tests, e.g. python setup.py test
-script:
   - export PYTHONPATH=$PYTHONPATH:`pwd -P`
   - cd test
+  
+# Command to run tests
+script:
   - coverage run --source=ssm,bin -m unittest2 discover --buffer
 
 after_success:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-stomp.py
+stomp.py<=3.1.6
 python-daemon
 python-ldap
 dirq

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+stomp.py
+python-daemon
+python-ldap
+dirq
+# Dependencies for testing
+unittest2
+coveralls


### PR DESCRIPTION
As per apel/apel#74.

- Activate Travis containerization in Travis file.
- Add caching of pip.
- Move pip install requirements to requirements.txt and remove pip install
  list so that Travis runs the default pip install command so that the pip
  cache works.
- Add comments.