### PR TITLE
Add delay to receiver restart on lost connection

### DIFF
--- a/bin/receiver.py
+++ b/bin/receiver.py
@@ -194,6 +194,8 @@ def main():
                     log.error('Connection lost.')
                     ssm.shutdown()
                     dc.close()
+                    log.info("Waiting for 10 minutes before restarting...")
+                    time.sleep(10 * 60)
                     log.info('Restarting SSM.')
                     dc.open()
                     ssm.startup()


### PR DESCRIPTION
Workaround for issue #26, but a proper fix should be found for that.

This delays the attempt to reconnect for ten minutes by which time broker problems are generally resolved.