### PR TITLE
Add python-devel as BuildRequires

### DIFF
--- a/apel-ssm.spec
+++ b/apel-ssm.spec
@@ -16,6 +16,9 @@ Source:         %{name}-%{version}-%{releasenumber}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch:      noarch
 
+%if ! (0%{?fedora} > 12 || 0%{?rhel} > 5)
+BuildRequires:  python-devel
+%endif
 Requires:       stomppy < 4.0.0, python-daemon, python-dirq, python-ldap
 Requires(pre):  shadow-utils
 


### PR DESCRIPTION
The spec file assume python is available in the buildroot, in our case it is not by default.

According to fedora/rhel convention BuildRequires:  python-devel is needed.

If we are targeting also rhel5 python-devel otherwise it can be python2-devel
