### PR TITLE
Replace hard coded cert/key used in testing with generated ones

### DIFF
--- a/test/test_crypto.py
+++ b/test/test_crypto.py
@@ -51,7 +51,7 @@ class TestEncryptUtils(unittest.TestCase):
         with open(TEST_CERT_FILE, 'r') as test_cert:
             cert_string = test_cert.read()
 
-        hash_name, unused_error = p1.communicate(cert_string)
+        hash_name, _unused_error = p1.communicate(cert_string)
 
         self.ca_certpath = os.path.join(TEST_CA_DIR, hash_name.strip() + '.0')
         with open(self.ca_certpath, 'w') as ca_cert:

--- a/test/test_crypto.py
+++ b/test/test_crypto.py
@@ -6,13 +6,10 @@ Created on 7 Dec 2011
 import unittest
 import logging
 import os
-import tempfile
-import shutil
 from subprocess import call, Popen, PIPE
 import quopri
 
-from ssm.crypto import _from_file, \
-    check_cert_key, \
+from ssm.crypto import check_cert_key, \
     get_certificate_subject, \
     get_signer_cert, \
     sign, \

--- a/test/test_crypto.py
+++ b/test/test_crypto.py
@@ -127,7 +127,7 @@ class TestEncryptUtils(unittest.TestCase):
 
         signed_msg2, error = p1.communicate(header_quopri_msg)
 
-        if (error != ''):
+        if error != '':
             self.fail(error)
 
         retrieved_msg, retrieved_dn = verify(signed_msg, TEST_CA_DIR, False)

--- a/test/test_crypto.py
+++ b/test/test_crypto.py
@@ -61,17 +61,7 @@ class TestEncryptUtils(unittest.TestCase):
         os.remove(TEST_CERT_FILE)
         os.remove(TEST_KEY_FILE)
         os.remove(self.ca_certpath)
- 
-    def test_from_file(self):
-        '''
-        Just test that the temporary file that has been set up contains the 
-        certificate it should.
-        '''
-        cert = _from_file(self.certpath)
-        
-        if not cert == TEST_CERT:
-            self.fail('The temporary file should include exactly the test certificate.')
-    
+
     def test_check_cert_key(self):
         '''
         This will print an error log message for the tests that are 

--- a/test/test_crypto.py
+++ b/test/test_crypto.py
@@ -76,10 +76,10 @@ class TestEncryptUtils(unittest.TestCase):
         except CryptoException:
             pass
         
-        if check_cert_key(self.certpath, self.certpath):
+        if check_cert_key(TEST_CERT_FILE, TEST_CERT_FILE):
             self.fail('Accepted certificate as key.')
         
-        if not check_cert_key(self.certpath, self.keypath):
+        if not check_cert_key(TEST_CERT_FILE, TEST_KEY_FILE):
             self.fail('Cert and key match but function failed.')
         
     def test_sign(self):
@@ -87,7 +87,7 @@ class TestEncryptUtils(unittest.TestCase):
         I haven't found a good way to test this yet.  Each time you sign a 
         message, the output has a random element, so you can't compare strings.
         '''
-        signed = sign(MSG, self.certpath, self.keypath)
+        signed = sign(MSG, TEST_CERT_FILE, TEST_KEY_FILE)
         
         if not 'MIME-Version' in signed:
             self.fail("Didn't get MIME message when signing.")
@@ -96,7 +96,7 @@ class TestEncryptUtils(unittest.TestCase):
             self.fail('The plaintext should be included in the signed message.')
         
         # Indirect testing, using the verify_message() method
-        retrieved_msg, retrieved_dn = verify(signed, self.ca_dir, False)
+        retrieved_msg, retrieved_dn = verify(signed, TEST_CA_DIR, False)
         
         if not retrieved_dn == TEST_CERT_DN:
             self.fail("The DN of the verified message didn't match the cert.")
@@ -105,8 +105,11 @@ class TestEncryptUtils(unittest.TestCase):
             self.fail("The verified message didn't match the original.")
             
     def test_verify(self):
-        
-        retrieved_msg, retrieved_dn = verify(SIGNED_MSG, self.ca_dir, False)
+
+        signed_msg = sign(MSG, TEST_CERT_FILE, TEST_KEY_FILE)
+        signed_msg2 = sign(MSG2, TEST_CERT_FILE, TEST_KEY_FILE)
+
+        retrieved_msg, retrieved_dn = verify(signed_msg, TEST_CA_DIR, False)
         
         if not retrieved_dn == TEST_CERT_DN:
             self.fail("The DN of the verified message didn't match the cert.")
@@ -114,7 +117,7 @@ class TestEncryptUtils(unittest.TestCase):
         if not retrieved_msg.strip() == MSG:
             self.fail("The verified messge didn't match the original.")
             
-        retrieved_msg2, retrieved_dn2 = verify(SIGNED_MSG2, self.ca_dir, False)
+        retrieved_msg2, retrieved_dn2 = verify(signed_msg2, TEST_CA_DIR, False)
         
         if not retrieved_dn2 == TEST_CERT_DN:
             print retrieved_dn2
@@ -128,12 +131,12 @@ class TestEncryptUtils(unittest.TestCase):
             
         # Try empty string    
         try:
-            verify('', self.ca_dir, False)
+            verify('', TEST_CA_DIR, False)
         except CryptoException:
             pass
         # Try rubbish
         try:
-            verify('Bibbly bobbly', self.ca_dir, False)
+            verify('Bibbly bobbly', TEST_CA_DIR, False)
         except CryptoException:
             pass
         # Try None arguments 
@@ -152,7 +155,9 @@ class TestEncryptUtils(unittest.TestCase):
         Check that incorrect input gives an appropriate error.
         '''
         # Valid certificate
-        dn = get_certificate_subject(TEST_CERT)
+        with open(TEST_CERT_FILE, 'r') as test_cert:
+            cert_string = test_cert.read()
+        dn = get_certificate_subject(cert_string)
         
         if not dn == TEST_CERT_DN:
             self.fail("Didn't retrieve correct DN from cert.")
@@ -174,32 +179,37 @@ class TestEncryptUtils(unittest.TestCase):
         Check that the certificate retrieved from the signed message
         matches the certificate used to sign it.
         '''
-        cert = get_signer_cert(SIGNED_MSG)
+        signed_msg = sign(MSG, TEST_CERT_FILE, TEST_KEY_FILE)
+
+        cert = get_signer_cert(signed_msg)
         # Remove any information preceding the encoded certificate.
         cert = cert[cert.find('-----BEGIN'):]
-        
-        if cert.strip() != TEST_CERT:
-            self.fail('Certificate retrieved from signature does not match \
-                    certificate used to sign.')
+
+        with open(TEST_CERT_FILE, 'r') as test_cert:
+            cert_string = test_cert.read()
+
+        if cert.strip() != cert_string.strip():
+            self.fail('Certificate retrieved from signature '
+                      'does not match certificate used to sign.')
         
     def test_encrypt(self):
         '''
         Not a correct test yet.
         '''
-        encrypted = encrypt(MSG, self.certpath)
+        encrypted = encrypt(MSG, TEST_CERT_FILE)
         
         if not 'MIME-Version' in encrypted:
             self.fail('Encrypted message is not MIME')
         
         # Indirect testing, using the decrypt_message function.
-        decrypted = decrypt(encrypted, self.certpath, self.keypath)
+        decrypted = decrypt(encrypted, TEST_CERT_FILE, TEST_KEY_FILE)
         
         if decrypted != MSG:
             self.fail("Encrypted message wasn't decrypted successfully.")
             
         # invalid cipher
         try:
-            encrypted = encrypt(MSG, self.certpath, 'aes1024')
+            encrypted = encrypt(MSG, TEST_CERT_FILE, 'aes1024')
         except CryptoException:
             pass    
         
@@ -209,8 +219,9 @@ class TestEncryptUtils(unittest.TestCase):
         Check that the encrypted message can be decrypted and returns the
         original message.
         '''
-        decrypted = decrypt(ENCRYPTED_MSG, self.certpath, self.keypath)
-        
+        encrypted = encrypt(MSG, TEST_CERT_FILE)
+        decrypted = decrypt(encrypted, TEST_CERT_FILE, TEST_KEY_FILE)
+       
         if decrypted.strip() != MSG:
             self.fail('Failed to decrypt message.') 
         
@@ -223,22 +234,25 @@ class TestEncryptUtils(unittest.TestCase):
         
         I can't check the CRLs of a self-signed certificate easily.
         '''
-        if not verify_cert(TEST_CERT, self.ca_dir, False):
+        with open(TEST_CERT_FILE, 'r') as test_cert:
+            cert_string = test_cert.read()
+
+        if not verify_cert(cert_string, TEST_CA_DIR, False):
             self.fail('The self signed certificate should validate against'
                       'itself in a CA directory.')
             
-        if verify_cert(TEST_CERT, '/tmp', False):
+        if verify_cert(cert_string, '/var/tmp', False):
             self.fail("The verify method isn't checking the CA dir correctly.")
             
-        if verify_cert('bloblo', self.ca_dir, False):
+        if verify_cert('bloblo', TEST_CA_DIR, False):
             self.fail('Nonsense successfully verified.')
  
-        if verify_cert(TEST_CERT, self.ca_dir, True):
+        if verify_cert(cert_string, TEST_CA_DIR, True):
             self.fail('The self-signed certificate should not be verified ' +
                       'if CRLs are checked.')
         
         try:    
-            if verify_cert(None, self.ca_dir, False):
+            if verify_cert(None, TEST_CA_DIR, False):
                 self.fail('Verified None rather than certificate string.')
         except CryptoException:
             pass
@@ -256,138 +270,6 @@ TEST_KEY_FILE = '/tmp/test.key'
 TEST_CA_DIR='/tmp'
 
 MSG = 'This is some test data.'
-
-# openssl smime -encrypt -in msg.text test.cert
-ENCRYPTED_MSG = '''MIME-Version: 1.0
-Content-Disposition: attachment; filename="smime.p7m"
-Content-Type: application/x-pkcs7-mime; smime-type=enveloped-data; name="smime.p7m"
-Content-Transfer-Encoding: base64
-
-MIIBSAYJKoZIhvcNAQcDoIIBOTCCATUCAQAxgeQwgeECAQAwSjA9MQswCQYDVQQG
-EwJVSzENMAsGA1UECgwEU1RGQzELMAkGA1UECwwCU0MxEjAQBgNVBAMMCVRlc3Qg
-Q2VydAIJAO90ilCRmLiVMA0GCSqGSIb3DQEBAQUABIGAk1+nwYVXhLe8XmbksVo6
-ZeQzdKMJV9pwP32eAiyncIPjm0GpyHpEvYaJ1+4+vDWyqA8MR912j0wVxTFKM3to
-RynPyC98gykaUflI9pKKvo/Um3FDV6goH1kLmT+/1qEOXjDff9iZBmZ+AWNM9LBN
-8kHoIMGymCqM8zZ6OUt3VIowSQYJKoZIhvcNAQcBMBoGCCqGSIb3DQMCMA4CAgCg
-BAirHdYutwNXk4AgB87AFNZ43NSQtj++5QXfRoRpfsBbs7GFgfOVA+ULT5Y=
-'''
-
-# openssl smime -sign -signer test.cert -inkey test.key -in msg.text -text
-SIGNED_MSG = '''MIME-Version: 1.0
-Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha1"; boundary="----D23AB54130D33D70AF44A49F6A408898"
-
-This is an S/MIME signed message
-
-------D23AB54130D33D70AF44A49F6A408898
-Content-Type: text/plain
-
-This is some test data.
-
-------D23AB54130D33D70AF44A49F6A408898
-Content-Type: application/x-pkcs7-signature; name="smime.p7s"
-Content-Transfer-Encoding: base64
-Content-Disposition: attachment; filename="smime.p7s"
-
-MIIETwYJKoZIhvcNAQcCoIIEQDCCBDwCAQExCzAJBgUrDgMCGgUAMAsGCSqGSIb3
-DQEHAaCCAkwwggJIMIIBsaADAgECAgkA73SKUJGYuJUwDQYJKoZIhvcNAQEFBQAw
-PTELMAkGA1UEBhMCVUsxDTALBgNVBAoMBFNURkMxCzAJBgNVBAsMAlNDMRIwEAYD
-VQQDDAlUZXN0IENlcnQwHhcNMTUxMTI2MTYwNjM2WhcNMTYxMTI2MTYwNjM2WjA9
-MQswCQYDVQQGEwJVSzENMAsGA1UECgwEU1RGQzELMAkGA1UECwwCU0MxEjAQBgNV
-BAMMCVRlc3QgQ2VydDCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAwCpCTGZ5
-c+IbjK17Pb1W/5eg8NfD168J9QsSqgx3yZ5oBuKLMBm5BPzMnngfTg+hvixKLJlG
-tEeEZDSIlRzFOZGIUthk+JwDVXkYWZI8WYE+4dOLtWfuzKPFhdaYUdsrIRtVvc0i
-iAx/kumvehINXpS6d7VDVlS9sVyUSOWEkPUCAwEAAaNQME4wHQYDVR0OBBYEFKSZ
-/T/S12miawyp5maL0GTENilxMB8GA1UdIwQYMBaAFKSZ/T/S12miawyp5maL0GTE
-NilxMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADgYEAVDWaM2axblp2cmYl
-3w5lHSibl4wExsn440Vnrhlpsc586+Jg2N/d57DyrO8SWVvSivN4VkENSevPCtKo
-Jb7dyszxlLUphg7XrJb9hcFUL5/mKV84x/0z/UTbD7aB9PDT8n0UwgbUCpB94P3v
-x7tQnr4ggbcIoOD/w2mxeG3Dd7QxggHLMIIBxwIBATBKMD0xCzAJBgNVBAYTAlVL
-MQ0wCwYDVQQKDARTVEZDMQswCQYDVQQLDAJTQzESMBAGA1UEAwwJVGVzdCBDZXJ0
-AgkA73SKUJGYuJUwCQYFKw4DAhoFAKCB2DAYBgkqhkiG9w0BCQMxCwYJKoZIhvcN
-AQcBMBwGCSqGSIb3DQEJBTEPFw0xNTExMjYxNjA5MTlaMCMGCSqGSIb3DQEJBDEW
-BBS4mGqHlYCOu0+aUiwPuT3+Q8yGEDB5BgkqhkiG9w0BCQ8xbDBqMAsGCWCGSAFl
-AwQBKjALBglghkgBZQMEARYwCwYJYIZIAWUDBAECMAoGCCqGSIb3DQMHMA4GCCqG
-SIb3DQMCAgIAgDANBggqhkiG9w0DAgIBQDAHBgUrDgMCBzANBggqhkiG9w0DAgIB
-KDANBgkqhkiG9w0BAQEFAASBgLXfxWyDPzKJ4zjozVMkzIHIIYC1NHCMQzIqFNmy
-LCORY7Yd1DTsHv1Qshq0u/yA+6BWCN0S3MlUWJbnAN4zbyAH7EkgVZkymkn4KQyL
-Si6AG6HNsYICeZW6gK/FW6ClKbXamygELe3Nx5cbfVEfT0Jsz2vj1gtS+tz87InJ
-SqqH
-
-------D23AB54130D33D70AF44A49F6A408898--'''
-
-# Created same way as SIGNED_MSG but text manually converted to quoted-printable
-# and Content-Type and Content-Transfer-Encoding fields added in manually.
-SIGNED_MSG2 = '''MIME-Version: 1.0
-Content-Type: multipart/signed; protocol="application/x-pkcs7-signature"; micalg="sha1"; boundary="----C4DE0669C598F78D53E9A61C6BB38924"
-
-This is an S/MIME signed message
-
-------C4DE0669C598F78D53E9A61C6BB38924
-Content-Type: text/xml; charset=utf8
-Content-Transfer-Encoding: quoted-printable
-
-<com:UsageRecord xmlns:com=3D"http://eu-emi.eu/namespaces/2012/11/computere=
-cord"><com:RecordIdentity com:recordId=3D"62991a08-909b-4516-aa30-3732ab3d8=
-998" com:createTime=3D"2013-02-22T15:58:44.567+01:00"/><com:JobIdentity><co=
-m:GlobalJobId>ac2b1157-7aff-42d9-945e-389aa9bbb19a</com:GlobalJobId><com:Lo=
-calJobId>7005</com:LocalJobId></com:JobIdentity><com:UserIdentity><com:Glob=
-alUserName com:type=3D"rfc2253">CN=3DBjoern Hagemeier,OU=3DForschungszentru=
-m Juelich GmbH,O=3DGridGermany,C=3DDE</com:GlobalUserName><com:LocalUserId>=
-bjoernh</com:LocalUserId><com:LocalGroup>users</com:LocalGroup></com:UserId=
-entity><com:JobName>HiLA</com:JobName><com:Status>completed</com:Status><co=
-m:ExitStatus>0</com:ExitStatus><com:Infrastructure com:type=3D"grid"/><com:=
-Middleware com:name=3D"unicore">unicore</com:Middleware><com:WallDuration>P=
-T0S</com:WallDuration><com:CpuDuration>PT0S</com:CpuDuration><com:ServiceLe=
-vel com:type=3D"HEPSPEC">1.0</com:ServiceLevel><com:Memory com:metric=3D"to=
-tal" com:storageUnit=3D"KB" com:type=3D"physical">0</com:Memory><com:Memory=
- com:metric=3D"total" com:storageUnit=3D"KB" com:type=3D"shared">0</com:Mem=
-ory><com:TimeInstant com:type=3D"uxToBssSubmitTime">2013-02-22T15:58:44.568=
-+01:00</com:TimeInstant><com:TimeInstant com:type=3D"uxStartTime">2013-02-2=
-2T15:58:46.563+01:00</com:TimeInstant><com:TimeInstant com:type=3D"uxEndTim=
-e">2013-02-22T15:58:49.978+01:00</com:TimeInstant><com:TimeInstant com:type=
-=3D"etime">2013-02-22T15:58:44+01:00</com:TimeInstant><com:TimeInstant com:=
-type=3D"ctime">2013-02-22T15:58:44+01:00</com:TimeInstant><com:TimeInstant =
-com:type=3D"qtime">2013-02-22T15:58:44+01:00</com:TimeInstant><com:TimeInst=
-ant com:type=3D"maxWalltime">2013-02-22T16:58:45+01:00</com:TimeInstant><co=
-m:NodeCount>1</com:NodeCount><com:Processors>2</com:Processors><com:EndTime=
->2013-02-22T15:58:45+01:00</com:EndTime><com:StartTime>2013-02-22T15:58:45+=
-01:00</com:StartTime><com:MachineName>zam052v15.zam.kfa-juelich.de</com:Mac=
-hineName><com:SubmitHost>zam052v02</com:SubmitHost><com:Queue com:descripti=
-on=3D"execution">batch</com:Queue><com:Site>zam052v15.zam.kfa-juelich.de</c=
-om:Site><com:Host com:primary=3D"false" com:description=3D"CPUS=3D2;SLOTS=
-=3D1,0">zam052v15</com:Host></com:UsageRecord>
-
-------C4DE0669C598F78D53E9A61C6BB38924
-Content-Type: application/x-pkcs7-signature; name="smime.p7s"
-Content-Transfer-Encoding: base64
-Content-Disposition: attachment; filename="smime.p7s"
-
-MIIETwYJKoZIhvcNAQcCoIIEQDCCBDwCAQExCzAJBgUrDgMCGgUAMAsGCSqGSIb3
-DQEHAaCCAkwwggJIMIIBsaADAgECAgkA73SKUJGYuJUwDQYJKoZIhvcNAQEFBQAw
-PTELMAkGA1UEBhMCVUsxDTALBgNVBAoMBFNURkMxCzAJBgNVBAsMAlNDMRIwEAYD
-VQQDDAlUZXN0IENlcnQwHhcNMTUxMTI2MTYwNjM2WhcNMTYxMTI2MTYwNjM2WjA9
-MQswCQYDVQQGEwJVSzENMAsGA1UECgwEU1RGQzELMAkGA1UECwwCU0MxEjAQBgNV
-BAMMCVRlc3QgQ2VydDCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAwCpCTGZ5
-c+IbjK17Pb1W/5eg8NfD168J9QsSqgx3yZ5oBuKLMBm5BPzMnngfTg+hvixKLJlG
-tEeEZDSIlRzFOZGIUthk+JwDVXkYWZI8WYE+4dOLtWfuzKPFhdaYUdsrIRtVvc0i
-iAx/kumvehINXpS6d7VDVlS9sVyUSOWEkPUCAwEAAaNQME4wHQYDVR0OBBYEFKSZ
-/T/S12miawyp5maL0GTENilxMB8GA1UdIwQYMBaAFKSZ/T/S12miawyp5maL0GTE
-NilxMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADgYEAVDWaM2axblp2cmYl
-3w5lHSibl4wExsn440Vnrhlpsc586+Jg2N/d57DyrO8SWVvSivN4VkENSevPCtKo
-Jb7dyszxlLUphg7XrJb9hcFUL5/mKV84x/0z/UTbD7aB9PDT8n0UwgbUCpB94P3v
-x7tQnr4ggbcIoOD/w2mxeG3Dd7QxggHLMIIBxwIBATBKMD0xCzAJBgNVBAYTAlVL
-MQ0wCwYDVQQKDARTVEZDMQswCQYDVQQLDAJTQzESMBAGA1UEAwwJVGVzdCBDZXJ0
-AgkA73SKUJGYuJUwCQYFKw4DAhoFAKCB2DAYBgkqhkiG9w0BCQMxCwYJKoZIhvcN
-AQcBMBwGCSqGSIb3DQEJBTEPFw0xNTExMjYxNjI0MTRaMCMGCSqGSIb3DQEJBDEW
-BBSsAbgU5Xqg/QNNwbXFBxU/k7PFmzB5BgkqhkiG9w0BCQ8xbDBqMAsGCWCGSAFl
-AwQBKjALBglghkgBZQMEARYwCwYJYIZIAWUDBAECMAoGCCqGSIb3DQMHMA4GCCqG
-SIb3DQMCAgIAgDANBggqhkiG9w0DAgIBQDAHBgUrDgMCBzANBggqhkiG9w0DAgIB
-KDANBgkqhkiG9w0BAQEFAASBgJ+Wn5Huc7Kyxw1yiHp1dbzVUpU1f4LWJiZLL3+c
-+6jJAU1yGqI9awV1XrM7vcrw7Rqo9DQTGWBJ57VW02BAfYiNsKax2rIQmSj74L6a
-2n4xYtDgTC27PBLqs7vX/9AzNx40MdWl61MTIXpJcgDAV0LzAyLZvE3ZlPZWrKz+
-KH1d
-
-------C4DE0669C598F78D53E9A61C6BB38924--'''
 
 MSG2 = '''<com:UsageRecord xmlns:com="http://eu-emi.eu/namespaces/2012/11/computerecord"><com:RecordIdentity com:recordId="62991a08-909b-4516-aa30-3732ab3d8998" com:createTime="2013-02-22T15:58:44.567+01:00"/><com:JobIdentity><com:GlobalJobId>ac2b1157-7aff-42d9-945e-389aa9bbb19a</com:GlobalJobId><com:LocalJobId>7005</com:LocalJobId></com:JobIdentity><com:UserIdentity><com:GlobalUserName com:type="rfc2253">CN=Bjoern Hagemeier,OU=Forschungszentrum Juelich GmbH,O=GridGermany,C=DE</com:GlobalUserName><com:LocalUserId>bjoernh</com:LocalUserId><com:LocalGroup>users</com:LocalGroup></com:UserIdentity><com:JobName>HiLA</com:JobName><com:Status>completed</com:Status><com:ExitStatus>0</com:ExitStatus><com:Infrastructure com:type="grid"/><com:Middleware com:name="unicore">unicore</com:Middleware><com:WallDuration>PT0S</com:WallDuration><com:CpuDuration>PT0S</com:CpuDuration><com:ServiceLevel com:type="HEPSPEC">1.0</com:ServiceLevel><com:Memory com:metric="total" com:storageUnit="KB" com:type="physical">0</com:Memory><com:Memory com:metric="total" com:storageUnit="KB" com:type="shared">0</com:Memory><com:TimeInstant com:type="uxToBssSubmitTime">2013-02-22T15:58:44.568+01:00</com:TimeInstant><com:TimeInstant com:type="uxStartTime">2013-02-22T15:58:46.563+01:00</com:TimeInstant><com:TimeInstant com:type="uxEndTime">2013-02-22T15:58:49.978+01:00</com:TimeInstant><com:TimeInstant com:type="etime">2013-02-22T15:58:44+01:00</com:TimeInstant><com:TimeInstant com:type="ctime">2013-02-22T15:58:44+01:00</com:TimeInstant><com:TimeInstant com:type="qtime">2013-02-22T15:58:44+01:00</com:TimeInstant><com:TimeInstant com:type="maxWalltime">2013-02-22T16:58:45+01:00</com:TimeInstant><com:NodeCount>1</com:NodeCount><com:Processors>2</com:Processors><com:EndTime>2013-02-22T15:58:45+01:00</com:EndTime><com:StartTime>2013-02-22T15:58:45+01:00</com:StartTime><com:MachineName>zam052v15.zam.kfa-juelich.de</com:MachineName><com:SubmitHost>zam052v02</com:SubmitHost><com:Queue com:description="execution">batch</com:Queue><com:Site>zam052v15.zam.kfa-juelich.de</com:Site><com:Host com:primary="false" com:description="CPUS=2;SLOTS=1,0">zam052v15</com:Host></com:UsageRecord>'''
 


### PR DESCRIPTION
This means we wont have to regenerate the hard coded values once a year.

I have removed the hard coded values and replaced them with constants that should contain the key, cert and ca directory path. Keys, certs and ca files are then generated for each test.

most of the changes were simply 
* `self.certpath` and `self.keypath` to `TEST_CERT_FILE` and `TEST_KEY_FILE`
* `self.ca_dir` to `TEST_CA_DIR`

I also removed `test_from_file`, as there is no need to check the file contains the certificate it should, as the cert file is now dynamically generated

Encrypted or signed messages are generated in the test case if needed. they could be done in `setUp` but are only needed for a few test cases.