### PR TITLE
Change Travis file to test against Python nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: python
 python:
   - "2.6"
   - "2.7"
-  - "3.5"
+  - "nightly"
 matrix:
   allow_failures:
-    - python: "3.5"
+    - python: "nightly"
   fast_finish: true
 
 # Route build to container-based infrastructure


### PR DESCRIPTION
Same as for apel/apel#134.

Change Travis file to test against latest nightly rather than a fixed Python 3 version so that it doesn't have to continually be manually changed.

At the moment this will be Python 3.7.0a0.