### PR TITLE
Tweak Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,11 @@ matrix:
 
 # Route build to container-based infrastructure
 sudo: false
+
 # Cache the dependencies installed by pip
 cache: pip
+# Avoid pip log from affecting cache
+before_cache: rm -fv ~/.cache/pip/log/debug.log
 
 # Install defaults to "pip install -r requirements.txt"
 
@@ -21,9 +24,10 @@ before_script:
   - export PYTHONPATH=$PYTHONPATH:`pwd -P`
   - cd test
   
-# Command to run tests
+# The coveralls module on PyPI (1.1) doesn't report branch coverage to
+# Coveralls, but should in the next release (1.2)
 script:
-  - coverage run --source=ssm,bin -m unittest2 discover --buffer
+  - coverage run --branch --source=ssm,bin -m unittest2 discover --buffer
 
 after_success:
   - coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ dirq
 # Dependencies for testing
 unittest2
 coveralls
+mock


### PR DESCRIPTION
Same as for apel/apel#137.

- Remove pip log before caching to avoid it affecting the cache.
- Add --branch argument to coverage run in preparation for coveralls
  module reporting coverage to Coveralls.io.
- Add mock to requirements and add final newline.