### PR TITLE
Alphacc patch 1

### DIFF
--- a/apel-ssm.spec
+++ b/apel-ssm.spec
@@ -16,9 +16,11 @@ Source:         %{name}-%{version}-%{releasenumber}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch:      noarch
 
+# Build requirement for non fedora-packager systems (CentOS).
 %if ! (0%{?fedora} > 12 || 0%{?rhel} > 5)
 BuildRequires:  python-devel
 %endif
+
 Requires:       stomppy < 4.0.0, python-daemon, python-dirq, python-ldap
 Requires(pre):  shadow-utils
 

--- a/apel-ssm.spec
+++ b/apel-ssm.spec
@@ -16,6 +16,9 @@ Source:         %{name}-%{version}-%{releasenumber}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch:      noarch
 
+%if ! (0%{?fedora} > 12 || 0%{?rhel} > 5)
+BuildRequires:  python-devel
+%endif
 Requires:       stomppy < 4.0.0, python-daemon, python-dirq, python-ldap
 Requires(pre):  shadow-utils
 


### PR DESCRIPTION
Closes #35.

Rebased version of #35 with additional comment. As this change doesn't affect our builds due to the conditional, I'm okay with the build requirement of python-devel, even though this seems to be over specifying the package required (only python is actually needed to build as this isn't a Python extension - which would require python-devel).