### PR TITLE
Merge two log messages into one and change level

### DIFF
--- a/bin/receiver.py
+++ b/bin/receiver.py
@@ -183,15 +183,14 @@ def main():
             time.sleep(1)
 
             if i % REFRESH_DNS == 0:
-                log.info('Refreshing the valid DNs.')
+                log.info('Refreshing valid DNs and then sending ping.')
                 dns = get_dns(options.dn_file)
                 ssm.set_dns(dns)
 
                 try:
-                    log.info('Sending ping.')
                     ssm.send_ping()
                 except NotConnectedException:
-                    log.error('Connection lost.')
+                    log.warn('Connection lost.')
                     ssm.shutdown()
                     dc.close()
                     log.info("Waiting for 10 minutes before restarting...")


### PR DESCRIPTION
- Merge refresh and ping log messages into one as don't really need to
have two when they always occur together.
- Reduce logging level of connection lost to warning as software is
still working correctly.