### PR TITLE
Add support for stomp.py v3.1.6+, including stomp.py v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The EPEL repository must be enabled.  This can be done by installing
 the RPM for your version of SL, which is available on this page:
 http://fedoraproject.org/wiki/EPEL
 
-The python stomp library (N.B. version 4 is currently not supported)
+The python stomp library (N.B. versions 3.1.1 and above are currently supported)
 * `yum install stomppy`
 
 The python daemon library

--- a/apel-ssm.spec
+++ b/apel-ssm.spec
@@ -21,7 +21,7 @@ BuildArch:      noarch
 BuildRequires:  python-devel
 %endif
 
-Requires:       stomppy, python-daemon, python-dirq, python-ldap
+Requires:       stomppy >= 3.1.1, python-daemon, python-dirq, python-ldap
 Requires(pre):  shadow-utils
 
 %define ssmconf %_sysconfdir/apel

--- a/apel-ssm.spec
+++ b/apel-ssm.spec
@@ -21,7 +21,7 @@ BuildArch:      noarch
 BuildRequires:  python-devel
 %endif
 
-Requires:       stomppy < 4.0.0, python-daemon, python-dirq, python-ldap
+Requires:       stomppy, python-daemon, python-dirq, python-ldap
 Requires(pre):  shadow-utils
 
 %define ssmconf %_sysconfdir/apel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-stomp.py<=3.1.6
+stomp.py
 python-daemon
 python-ldap
 dirq

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-stomp.py
+stomp.py>=3.1.1
 python-daemon
 python-ldap
 dirq

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ def main():
           url='http://apel.github.io/',
           download_url='https://github.com/apel/ssm/releases',
           license='Apache License, Version 2.0',
-          install_requires=['stomp.py<=3.1.6', 'python-ldap', 'dirq'],
+          install_requires=['stomp.py', 'python-ldap', 'dirq'],
           extras_require={
               'python-daemon': ['python-daemon'],
           },

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ def main():
           url='http://apel.github.io/',
           download_url='https://github.com/apel/ssm/releases',
           license='Apache License, Version 2.0',
-          install_requires=['stomp.py', 'python-ldap', 'dirq'],
+          install_requires=['stomp.py>=3.1.1', 'python-ldap', 'dirq'],
           extras_require={
               'python-daemon': ['python-daemon'],
           },

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -446,7 +446,10 @@ class Ssm2(stomp.ConnectionListener):
             log.info('Will send messages to: %s', self._dest)
 
         if self._listen is not None:
-            self._conn.subscribe(destination=self._listen, ack='auto')
+            # Use a static ID for the subscription ID because we only ever have
+            # one subscription within a connection and ID is only considered
+            # to differentiate subscriptions within a connection.
+            self._conn.subscribe(destination=self._listen, id=1, ack='auto')
             log.info('Subscribing to: %s', self._listen)
 
         i = 0

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -39,7 +39,6 @@ except ImportError:
 import os
 import socket
 import time
-import uuid
 import logging
 
 # Set up logging 
@@ -447,11 +446,11 @@ class Ssm2(stomp.ConnectionListener):
             log.info('Will send messages to: %s', self._dest)
 
         if self._listen is not None:
-            # Giving each subscription an unique id allows a single connection
-            # to have multiple open subscriptions with a server.
-            # We use uuid4 because uuid4 is sufficient to create an unique ID.
+            # Use the current time to create a subscription id to avoid
+            # any potential id clashes
+            sub_id = str(time.time())
             self._conn.subscribe(destination=self._listen,
-                                 id=uuid.uuid4(),
+                                 id=sub_id,
                                  ack='auto')
 
             log.info('Subscribing to: %s', self._listen)

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -39,6 +39,7 @@ except ImportError:
 import os
 import socket
 import time
+import uuid
 import logging
 
 # Set up logging 
@@ -447,11 +448,11 @@ class Ssm2(stomp.ConnectionListener):
             log.info('Will send messages to: %s', self._dest)
 
         if self._listen is not None:
-            # Use the current time to create a subscription id to avoid
-            # any potential id clashes
-            sub_id = str(time.time())
+            # Giving each subscription an unique id allows a single connection
+            # to have multiple open subscriptions with a server.
+            # We use uuid4 because uuid4 is sufficient to create an unique ID.
             self._conn.subscribe(destination=self._listen,
-                                 id=sub_id,
+                                 id=uuid.uuid4(),
                                  ack='auto')
 
             log.info('Subscribing to: %s', self._listen)

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -133,12 +133,27 @@ class Ssm2(stomp.ConnectionListener):
     ##########################################################################
     # Methods called by stomppy
     ##########################################################################
-            
-    def on_send(self, headers, unused_body):
+
+    def on_send(self, frame, unused_body=None):
         '''
         Called by stomppy when a message is sent.
+
+        unused_body is only present for to have a backward compatible
+        method signiture when using stomp.py v3.1.X
         '''
-        log.debug('Sent message: %s', headers['empa-id'])
+        try:
+            # Try the stomp.py v4 way first
+            empaid = frame.headers['empa-id']
+        except KeyError:
+            # Then you are most likely using stomp.py v4.
+            # on_send is now triggered on non message frames
+            # (such as 'CONNECT' frames) and as such without an empa-id.
+            empaid = 'no empa-id'
+        except AttributeError:
+            # Then you are likely using stomp.py v3
+            empaid = frame['empa-id']
+
+        log.debug('Sent message: %s', empaid)
 
     def on_message(self, headers, body):
         '''

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -230,7 +230,15 @@ class Ssm2(stomp.ConnectionListener):
         '''
         log.info('Broker received message: %s', headers['receipt-id'])
         self._last_msg = headers['receipt-id']
-        
+
+    def on_receiver_loop_completed(self, _unused_headers, _unused_body):
+        '''
+        Called by stompy when the receiver loop ends.
+
+        This is usually trigger as part of a disconnect.
+        '''
+        log.debug('on_receiver_loop_completed called.')
+
     ##########################################################################
     # Message handling methods
     ##########################################################################

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -439,7 +439,13 @@ class Ssm2(stomp.ConnectionListener):
             log.info('Will send messages to: %s', self._dest)
 
         if self._listen is not None:
-            self._conn.subscribe(destination=self._listen, ack='auto')
+            # Use the current time to create a subscription id to avoid
+            # any potential id clashes
+            sub_id = str(time.time())
+            self._conn.subscribe(destination=self._listen,
+                                 id=sub_id,
+                                 ack='auto')
+
             log.info('Subscribing to: %s', self._listen)
 
         i = 0

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -138,8 +138,8 @@ class Ssm2(stomp.ConnectionListener):
         '''
         Called by stomppy when a message is sent.
 
-        unused_body is only present for to have a backward compatible
-        method signiture when using stomp.py v3.1.X
+        unused_body is only present to have a backward compatible
+        method signature when using stomp.py v3.1.X
         '''
         try:
             # Try the stomp.py v4 way first

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -375,6 +375,9 @@ class Ssm2(stomp.ConnectionListener):
                 raise ImportError("SSL connection requested but the ssl module "
                                   "wasn't found.")
             log.info('Connecting using SSL...')
+        else:
+            log.warning("SSL connection not requested, your messages may be "
+                        "intercepted.")
 
         # _conn will use the default SSL version specified by stomp.py
         self._conn = stomp.Connection([(host, port)],

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -458,7 +458,7 @@ class Ssm2(stomp.ConnectionListener):
         if it is not ended.
         '''
         try:
-            self._conn.stop()  # Same as diconnect() but waits for thread exit
+            self._conn.disconnect()
         except (stomp.exception.NotConnectedException, socket.error):
             self._conn = None
         except AttributeError:

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -124,8 +124,14 @@ class Ssm2(stomp.ConnectionListener):
                     raise Ssm2Exception('Failed to verify server certificate %s against CA path %s.'
                                         % (self._enc_cert, self._capath))
 
-        # Stop the underlying stomp.py module spamming the log
-        logging.getLogger("stomp.py").setLevel(logging.WARNING)
+        # If the overall SSM log level is info, we want to only
+        # see log entries from stomp.py at the warning level and above.
+        if logging.getLogger("ssm.ssm2").getEffectiveLevel() == logging.INFO:
+            logging.getLogger("stomp.py").setLevel(logging.WARNING)
+        # If the overall SSM log level is debug, we want to only
+        # see log entries from stomp.py at the info level and above.
+        elif logging.getLogger("ssm.ssm2").getEffectiveLevel() == logging.DEBUG:
+            logging.getLogger("stomp.py").setLevel(logging.INFO)
 
     def set_dns(self, dn_list):
         '''

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -376,7 +376,6 @@ class Ssm2(stomp.ConnectionListener):
         # _conn will use the default SSL version specified by stomp.py
         self._conn = stomp.Connection([(host, port)],
                                       use_ssl=self._use_ssl,
-                                      reconnect_attempts_max=1,
                                       ssl_key_file=self._key,
                                       ssl_cert_file=self._cert,
                                       timeout=Ssm2.CONNECTION_TIMEOUT)

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -291,8 +291,13 @@ class Ssm2(stomp.ConnectionListener):
                 to_send = crypto.encrypt(to_send, self._enc_cert)
         else:
             to_send = ''
-            
-        self._conn.send(to_send, headers=headers)
+
+        try:
+            # Try using the v4 method signiture
+            self._conn.send(self._dest, to_send, headers=headers)
+        except TypeError:
+            # If it fails, use the v3 metod signiture
+            self._conn.send(to_send, headers=headers)
 
     def send_ping(self):
         '''

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -232,11 +232,11 @@ class Ssm2(stomp.ConnectionListener):
         self._last_msg = headers['receipt-id']
 
     def on_receiver_loop_completed(self, _unused_headers, _unused_body):
-        '''
+        """
         Called by stompy when the receiver loop ends.
 
         This is usually trigger as part of a disconnect.
-        '''
+        """
         log.debug('on_receiver_loop_completed called.')
 
     ##########################################################################

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -366,6 +366,7 @@ class Ssm2(stomp.ConnectionListener):
         Create the self._connection object with the appropriate properties,
         but don't try to start the connection.
         '''
+        log.info("Established connection to %s, port %i", host, port)
         if self._use_ssl:
             if ssl is None:
                 raise ImportError("SSL connection requested but the ssl module "

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -446,13 +446,7 @@ class Ssm2(stomp.ConnectionListener):
             log.info('Will send messages to: %s', self._dest)
 
         if self._listen is not None:
-            # Use the current time to create a subscription id to avoid
-            # any potential id clashes
-            sub_id = str(time.time())
-            self._conn.subscribe(destination=self._listen,
-                                 id=sub_id,
-                                 ack='auto')
-
+            self._conn.subscribe(destination=self._listen, ack='auto')
             log.info('Subscribing to: %s', self._listen)
 
         i = 0

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -29,12 +29,7 @@ from dirq.QueueSimple import QueueSimple
 from dirq.queue import Queue
 
 import stomp
-# Exception changed name between stomppy versions
-try:
-    from stomp.exception import ConnectFailedException
-except ImportError:
-    from stomp.exception import ReconnectFailedException \
-            as ConnectFailedException
+from stomp.exception import ConnectFailedException
 
 import os
 import socket


### PR DESCRIPTION
resolves #7 

This also removes support for stomp.py v2 and most likely v3.0. Those versions are not pip installable so I can't confirm.

* rework `_initialise_connection` to do everything in the connection constructor. Previously some attributes were set after the constructor to support stomp.py v2. 
* rework `start_connection`, `on_send` and `_send_msg` to support v3.1.6+ and v4
* replace a call to `stop()` with `disconnect()` as they are functionally the same in v3 and `stop()` does nothing in v4
* add an `on_receiver_loop_completed` handler to reduce some of the noise from stomp.py v4
* removes version constraint in requirements.txt for stomp.py