### PR TITLE
Stop setup.py installing /etc/apel/logging.cfg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,7 @@ def main():
 
     # conf_files will later be copied to conf_dir
     conf_dir = '/etc/apel/'
-    conf_files = ['conf/logging.cfg',
-                  'conf/receiver.cfg',
+    conf_files = ['conf/receiver.cfg',
                   'conf/sender.cfg',
                   'conf/dns']
 


### PR DESCRIPTION
As it is not installed by the RPM and having it installed causes confusion when the logging config section is only specified in the sender or receiver config but `logging.cfg` is under `/etc/apel`, as in that case it takes precedence over the supplied configs logging section.
