### PR TITLE
Add comment to logging.cfg to clarify usage

### DIFF
--- a/conf/logging.cfg
+++ b/conf/logging.cfg
@@ -1,3 +1,7 @@
+# This logging configuration file is not installed by RPM or setup.py, but if
+# placed in /etc/apel alongside the other config files it will override them.
+# Advanced use only. See the Python docs for the "logging.config" module.
+
 [loggers]
 keys=root,SSM,Crypto,stomp.py
 


### PR DESCRIPTION
Resolves #57.

`logging.cfg` seems to have only ever caused problems. So some explanatory comments should help avoid problems.