### PR TITLE
Expired server cert check

### DIFF
--- a/conf/sender.cfg
+++ b/conf/sender.cfg
@@ -24,8 +24,10 @@ use_ssl: true
 certificate: /etc/grid-security/hostcert.pem
 key: /etc/grid-security/hostkey.pem
 capath: /etc/grid-security/certificates
+
 # If supplied, outgoing messages will be encrypted using this certificate.
-# It must be the cert of the accounting repository that you are sending to.
+# May be used in addition to 'use_ssl'. If used, it must be the certificate of
+# the final server that's receiving your messages; not your own, nor the broker.
 #server_cert: /etc/grid-security/servercert.pem
 
 ################################################################################

--- a/conf/sender.cfg
+++ b/conf/sender.cfg
@@ -24,8 +24,8 @@ use_ssl: true
 certificate: /etc/grid-security/hostcert.pem
 key: /etc/grid-security/hostkey.pem
 capath: /etc/grid-security/certificates
-# If this is supplied, outgoing messages will be encrypted
-# using this certificate
+# If supplied, outgoing messages will be encrypted using this certificate.
+# It must be the cert of the accounting repository that you are sending to.
 #server_cert: /etc/grid-security/servercert.pem
 
 ################################################################################

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -116,7 +116,8 @@ class Ssm2(stomp.ConnectionListener):
             if not crypto.verify_cert_date(enc_cert):
                 raise Ssm2Exception(
                     'Encryption certificate %s has expired. Please obtain the '
-                    'current one for the server you are sending to.' % enc_cert
+                    'new one from the final server receiving your messages.' %
+                    enc_cert
                 )
             if verify_enc_cert:
                 if not crypto.verify_cert_path(self._enc_cert, self._capath, self._check_crls):

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -120,10 +120,9 @@ class Ssm2(stomp.ConnectionListener):
                 )
             if verify_enc_cert:
                 if not crypto.verify_cert_path(self._enc_cert, self._capath, self._check_crls):
-                    raise Ssm2Exception('Failed to verify server certificate %s against CA path %s.' 
-                                         % (self._enc_cert, self._capath))
-            
-    
+                    raise Ssm2Exception('Failed to verify server certificate %s against CA path %s.'
+                                        % (self._enc_cert, self._capath))
+
     def set_dns(self, dn_list):
         '''
         Set the list of DNs which are allowed to sign incoming messages.

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -112,6 +112,12 @@ class Ssm2(stomp.ConnectionListener):
             log.info('Messages will be encrypted using %s', enc_cert)
             if not os.path.isfile(self._enc_cert):
                 raise Ssm2Exception('Specified certificate file does not exist: %s.' % self._enc_cert)
+            # Check that the encyption certificate has not expired.
+            if not crypto.verify_cert_date(enc_cert):
+                raise Ssm2Exception(
+                    'Encryption certificate %s has expired. Please obtain the '
+                    'current one for the server you are sending to.' % enc_cert
+                )
             if verify_enc_cert:
                 if not crypto.verify_cert_path(self._enc_cert, self._capath, self._check_crls):
                     raise Ssm2Exception('Failed to verify server certificate %s against CA path %s.' 

--- a/test/test_ssm.py
+++ b/test/test_ssm.py
@@ -104,6 +104,16 @@ class TestSsm(unittest.TestCase):
         # If the test gets here, then it has failed as no exception was thrown.
         self.fail('An SSM instance was created with an expired certificate!')
 
+    def test_init_expired_server_cert(self):
+        """Check that exception is raised if server cert has expired."""
+        self.assertRaises(
+            Ssm2Exception, Ssm2, self._brokers, self._msgdir, TEST_CERT_FILE,
+            self._key_path, dest=self._dest, enc_cert=self._expired_cert_path,
+            verify_enc_cert=False
+        )
+        # verify_enc_cert is set to False as we don't want to risk raising an
+        # exception by failing cert verification.
+
 
 TEST_CERT_FILE = '/tmp/test.crt'
 


### PR DESCRIPTION
Follow on from #40. This is fairly minor and in a sense fixes an issue for clients so I'm including it in 2.2.1.

This PR:
- changes the comment in the config for `server_cert` to clarify its usage
- adds checking of the server cert expiry
- adds corresponding unit test
- tidies a little whitespace.