### PR TITLE
Fix for rejected msgs being written out raw

### DIFF
--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -163,6 +163,11 @@ class Ssm2(stomp.ConnectionListener):
             if extracted_msg is None or err_msg is not None:
                 if signer is None:  # crypto failed
                     signer = 'Not available.'
+                elif extracted_msg is not None:
+                    # If there is a signer then it was rejected for not being
+                    # in the DNs list, so we can use the extracted msg, which
+                    # allows the msg to be reloaded if needed.
+                    body = extracted_msg
 
                 log.warn("Message rejected: %s", err_msg)
 

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -155,12 +155,12 @@ class Ssm2(stomp.ConnectionListener):
             empaid = 'noid'
 
         log.info("Received message. ID = %s", empaid)
-        raw_msg, signer, err_msg = self._handle_msg(body)
+        extracted_msg, signer, err_msg = self._handle_msg(body)
 
         try:
             # If the message is empty or the error message is not empty
             # then reject the message.
-            if raw_msg is None or err_msg is not None:
+            if extracted_msg is None or err_msg is not None:
                 if signer is None:  # crypto failed
                     signer = 'Not available.'
 
@@ -173,7 +173,7 @@ class Ssm2(stomp.ConnectionListener):
                 log.info("Message saved to reject queue as %s", name)
 
             else:  # message verified ok
-                name = self._inq.add({'body': raw_msg,
+                name = self._inq.add({'body': extracted_msg,
                                       'signer': signer,
                                       'empaid': empaid})
                 log.info("Message saved to incoming queue as %s", name)

--- a/test/test_ssm.py
+++ b/test/test_ssm.py
@@ -86,6 +86,11 @@ class TestSsm(unittest.TestCase):
         test_ssm.on_message({'nothing': 'dummy'}, 'Not signed or encrypted.')
         os.chmod(self._msgdir, 0777)
 
+        # Simple test for message with ID of 'ping'.
+        test_ssm.on_message({'empa-id': 'ping'}, 'body')
+        # Simple test for message with an ID but no real content.
+        test_ssm.on_message({'empa-id': '012345'}, 'body')
+
     def test_init_expired_cert(self):
         """Test right exception is thrown creating an SSM with expired cert."""
         expected_error = ('Certificate %s has expired.'


### PR DESCRIPTION
Resolves #54.

Note that this change should only apply to messages that are rejected for the signer not being in the valid DNs list.

No unit tests for this new code as it seems like it would be a disproportionate effort to write test cases for this. As this just changes how rejected messages are handled, plan is to apply this to preprod and observe.