### PR TITLE
Add handling for unhandled exceptions

### DIFF
--- a/ssm/crypto.py
+++ b/ssm/crypto.py
@@ -160,7 +160,10 @@ def verify(signed_text, capath, check_crl):
     
     # SMIME header and message body are separated by a blank line
     lines = message.strip().splitlines()
-    blankline = lines.index('')
+    try:
+        blankline = lines.index('')
+    except ValueError:
+        raise CryptoException('No blank line between message header and body')
     headers = '\n'.join(lines[:blankline])
     body = '\n'.join(lines[blankline + 1:])
     # two possible encodings

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -183,7 +183,7 @@ class Ssm2(stomp.ConnectionListener):
                                       'empaid': empaid})
                 log.info("Message saved to incoming queue as %s", name)
 
-        except OSError, e:
+        except (IOError, OSError) as e:
             log.error('Failed to read or write file: %s', e)
         
     def on_error(self, unused_headers, body):


### PR DESCRIPTION
Partially resolves #62. (Will write up remaining issue separately.)

1. Add `try...except` to catch `ValueError`s raised when there's no blank line
beween header and body of an otherwise valid signed message. Raising a
`CryptoException` means that the message will be rejected nicely in
`Ssm2.on_message`.
1. Catch `IOError` in addition to `OSError` in `on_message` as there is [no real
difference between them](https://www.python.org/dev/peps/pep-3151/#confusing-set-of-os-related-exceptions) and we sometimes get the former being raised.

Part 1 allows the message to be written out to the reject queue. 2 doesn't, but it's an odd situation that will need some more work - see #64.