### PR TITLE
Freeze python-daemon at 2.1.X

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ http://fedoraproject.org/wiki/EPEL
 The python stomp library (N.B. versions 3.1.1 and above are currently supported)
 * `yum install stomppy`
 
-The python daemon library
+The python daemon library (N.B. only versions below 2.2.0 are currently supported)
 * `yum install python-daemon`
 
 The python ldap library

--- a/apel-ssm.spec
+++ b/apel-ssm.spec
@@ -21,7 +21,7 @@ BuildArch:      noarch
 BuildRequires:  python-devel
 %endif
 
-Requires:       stomppy >= 3.1.1, python-daemon, python-dirq, python-ldap
+Requires:       stomppy >= 3.1.1, python-daemon < 2.2.0, python-dirq, python-ldap
 Requires(pre):  shadow-utils
 
 %define ssmconf %_sysconfdir/apel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 stomp.py>=3.1.1
-python-daemon
+python-daemon<2.2.0
 python-ldap
 dirq
 # Dependencies for testing

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ def main():
           license='Apache License, Version 2.0',
           install_requires=['stomp.py>=3.1.1', 'python-ldap', 'dirq'],
           extras_require={
-              'python-daemon': ['python-daemon'],
+              'python-daemon': ['python-daemon<2.2.0'],
           },
           packages=find_packages(exclude=['bin']),
           scripts=['bin/ssmreceive', 'bin/ssmsend'],


### PR DESCRIPTION
- It seems python-daemon 2.2.0 released on 15/08/2018 breaks
  support for python 2.6.
- The obvious effect is the travis tests and docker build
  started to fail this morning.
- Freezing this package should allow the tests and builds to pass

Example of failed Travis test:
```
Collecting python-daemon (from -r requirements.txt (line 2))
  Downloading https://files.pythonhosted.org/packages/99/2a/75fe6aa7086e838570f29899f674e7896a42be26d9fff33f90d990e599d2/python-daemon-2.2.0.tar.gz (79kB)
    100% |████████████████████████████████| 81kB 6.0MB/s 
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-rHUVES/python-daemon/setup.py", line 21, in <module>
        import version
      File "version.py", line 520
        for item in versions}
          ^
    SyntaxError: invalid syntax
```

Example of failed Docker build:
```
Collecting python-daemon (from -r requirements.txt (line 2))
Downloading https://files.pythonhosted.org/packages/99/2a/75fe6aa7086e838570f29899f674e7896a42be26d9fff33f90d990e599d2/python-daemon-2.2.0.tar.gz (79kB)
Complete output from command python setup.py egg_info:
Traceback (most recent call last):
File "<string>", line 1, in <module>
File "/tmp/pip-build-5grvNz/python-daemon/setup.py", line 102, in <module>
setup(**setup_kwargs)
File "/usr/lib64/python2.7/distutils/core.py", line 112, in setup
_setup_distribution = dist = klass(attrs)
File "version.py", line 652, in __init__
super(ChangelogAwareDistribution, self).__init__(*args, **kwargs)
File "/usr/lib/python2.7/site-packages/setuptools/dist.py", line 265, in __init__
self.fetch_build_eggs(attrs.pop('setup_requires'))
File "/usr/lib/python2.7/site-packages/setuptools/dist.py", line 289, in fetch_build_eggs
parse_requirements(requires), installer=self.fetch_build_egg
File "/usr/lib/python2.7/site-packages/pkg_resources.py", line 618, in resolve
dist = best[req.key] = env.best_match(req, self, installer)
File "/usr/lib/python2.7/site-packages/pkg_resources.py", line 862, in best_match
return self.obtain(req, installer) # try and download/install
File "/usr/lib/python2.7/site-packages/pkg_resources.py", line 874, in obtain
return installer(requirement)
File "/usr/lib/python2.7/site-packages/setuptools/dist.py", line 337, in fetch_build_egg
cmd.ensure_finalized()
File "/usr/lib64/python2.7/distutils/cmd.py", line 109, in ensure_finalized
self.finalize_options()
File "/usr/lib/python2.7/site-packages/setuptools/command/easy_install.py", line 230, in finalize_options
'dist_version': self.distribution.get_version(),
File "version.py", line 671, in get_version
version_info = self.get_version_info()
File "version.py", line 667, in get_version_info
version_info = generate_version_info_from_changelog(changelog_path)
File "version.py", line 495, in generate_version_info_from_changelog
versions_all_json = changelog_to_version_info_collection(infile)
File "version.py", line 450, in changelog_to_version_info_collection
import docutils.core
ImportError: No module named docutils.core
```

It's weird that it cause two separate errors, but this PR should fix both the Travis tests and the Docker Build