### PR TITLE
Collapse apt-gets to single line and add pip

### DIFF
--- a/scripts/ssm-build-deb.sh
+++ b/scripts/ssm-build-deb.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-# Execute the following as root to install lintian and fpm:
-# apt-get install lintian
-# apt-get install ruby ruby-dev build-essential
+# Execute the following as root to install lintian, pip, and fpm:
+# apt-get install lintian ruby ruby-dev build-essential python-pip
 # gem install --no-ri --no-rdoc fpm
 
 # Then run this file, as any user, altering the


### PR DESCRIPTION
- Pip is needed for fpm. This was missing before so would lead to error during the build.
- Apt-get install commands collapsed to single line to save copy pasting.

Tested on a fresh Ubuntu Trusty VM.