### PR TITLE
Split test requirements out and add constraint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,17 +17,18 @@ cache: pip
 before_cache: rm -fv ~/.cache/pip/log/debug.log
 
 install:
+  # Base requirements for ssm
   - pip install -r requirements.txt
+  # Additional requirements for the unit and coverage tests
   - pip install -r requirements-test.txt
 
+# Commands to prepare environment for the test
 before_script:
   - export TMPDIR=$PWD/tmp
   - mkdir $TMPDIR
   - export PYTHONPATH=$PYTHONPATH:`pwd -P`
   - cd test
 
-script:
-  - coverage run --branch --source=ssm,bin -m unittest2 discover --buffer
+script: coverage run --branch --source=ssm,bin -m unittest2 discover --buffer
 
-after_success:
-  - coveralls
+after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,9 @@ cache: pip
 # Avoid pip log from affecting cache
 before_cache: rm -fv ~/.cache/pip/log/debug.log
 
-# Install defaults to "pip install -r requirements.txt"
+install:
+  - pip install -r requirements.txt
+  - pip install -r requirements-test.txt
 
 before_script:
   - export TMPDIR=$PWD/tmp

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,4 @@
 # Constraints that apply to requirements-test.txt
+
 # coveralls dependency that needs an older version for Python 2.6
 pycparser<2.19

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,4 +1,4 @@
-# Constraints that apply to requirements-test.txt
+# Constraints that apply to pip installed requirements
 
 # coveralls dependency that needs an older version for Python 2.6
 pycparser<2.19

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,3 @@
+# Constraints that apply to requirements-test.txt
+# coveralls dependency that needs an older version for Python 2.6
+pycparser<2.19

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,6 @@
+# Constraints on requirements below
+-c constraints.txt
+# Requirements for testing
+unittest2
+coveralls
+mock

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,8 @@
-# Constraints on requirements below
+# Additional requirements for the unit and coverage tests
+
+# Constraints on the requirements below
 -c constraints.txt
-# Requirements for testing
+
 unittest2
 coveralls
 mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,3 @@ stomp.py>=3.1.1
 python-daemon<2.2.0
 python-ldap
 dirq
-# Dependencies for testing
-unittest2
-coveralls
-mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+# Base requirements for ssm
+
 stomp.py>=3.1.1
 python-daemon<2.2.0
 python-ldap


### PR DESCRIPTION
The weekly cron build failed which raised an issue with a dependency of a dependency not supporting Python 2.6 any more. This PR fixes that (though the longer term fix is to deprecate Python 2.6 support).

- Move test requirements into separate requirements file to make it
clearer that they are only needed for running unit tests.
- Add constraints file called from the test requirements file to limit
one of coveralls' dependencies to an earlier version that works with
Python 2.6.