### PR TITLE
Fixing of on_error exception hanging

### DIFF
--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -253,12 +253,15 @@ class Ssm2(stomp.ConnectionListener):
         except (IOError, OSError) as e:
             log.error('Failed to read or write file: %s', e)
 
-    def on_error(self, unused_headers, body):
+    def on_error(self, headers, body):
         '''
         Called by stomppy when an error frame is received.
         '''
-        log.warn('Error message received: %s', body)
-        raise Ssm2Exception()
+        if 'No user for client certificate: ' in headers['message']:
+            log.error('The following certificate is not authorised: %s',
+                      headers['message'].split(':')[1])
+        else:
+            log.error('Error message received: %s', body)
 
     def on_connected(self, unused_headers, unused_body):
         '''

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -621,8 +621,7 @@ class Ssm2(stomp.ConnectionListener):
                     connection object was initialised.')
 
         self._conn.start()
-        self._conn.connect(wait = True)
-
+        self._conn.connect(wait=False)
         if self._dest is not None:
             log.info('Will send messages to: %s', self._dest)
 

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -539,6 +539,8 @@ class Ssm2(stomp.ConnectionListener):
             log.warning("SSL connection not requested, your messages may be "
                         "intercepted.")
 
+        log.info("Using stomp.py version: %s", stomp.__version__)
+
         # _conn will use the default SSL version specified by stomp.py
         self._conn = stomp.Connection([(host, port)],
                                       use_ssl=self._use_ssl,

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -539,8 +539,6 @@ class Ssm2(stomp.ConnectionListener):
             log.warning("SSL connection not requested, your messages may be "
                         "intercepted.")
 
-        log.info("Using stomp.py version: %s", stomp.__version__)
-
         # _conn will use the default SSL version specified by stomp.py
         self._conn = stomp.Connection([(host, port)],
                                       use_ssl=self._use_ssl,
@@ -561,6 +559,8 @@ class Ssm2(stomp.ConnectionListener):
         if self._protocol == Ssm2.AMS_MESSAGING:
             log.debug('handle_connect called for AMS, doing nothing.')
             return
+
+        log.info("Using stomp.py version %s.%s.%s.", *stomp.__version__)
 
         for host, port in self._brokers:
             self._initialise_connection(host, port)

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -622,15 +622,6 @@ class Ssm2(stomp.ConnectionListener):
 
         self._conn.start()
         self._conn.connect(wait=False)
-        if self._dest is not None:
-            log.info('Will send messages to: %s', self._dest)
-
-        if self._listen is not None:
-            # Use a static ID for the subscription ID because we only ever have
-            # one subscription within a connection and ID is only considered
-            # to differentiate subscriptions within a connection.
-            self._conn.subscribe(destination=self._listen, id=1, ack='auto')
-            log.info('Subscribing to: %s', self._listen)
 
         i = 0
         while not self.connected:
@@ -640,6 +631,16 @@ class Ssm2(stomp.ConnectionListener):
                 err += 'Check the connection details.'
                 raise Ssm2Exception(err)
             i += 1
+
+        if self._dest is not None:
+            log.info('Will send messages to: %s', self._dest)
+
+        if self._listen is not None:
+            # Use a static ID for the subscription ID because we only ever have
+            # one subscription within a connection and ID is only considered
+            # to differentiate subscriptions within a connection.
+            self._conn.subscribe(destination=self._listen, id=1, ack='auto')
+            log.info('Subscribing to: %s', self._listen)
 
     def close_connection(self):
         '''


### PR DESCRIPTION
Resolves #92.

The key parts of this change are the swap from `self._conn.connect(wait=True)` to `=False` and the removal of the raising of an exception in `on_error` - these changes allow SSM to retry the connection after a timeout (rather than blocking) and to then exit gracefully once all brokers have been tried.

`start_connection` has been rearranged to check if connected just after connecting, rather than after creating a subscription, so that a subscription is not attempted without a connection. This is to mitigate the removal of the connection wait.

Additionally, the error message you get if you try to connect without being authorised has been improved (no more Java error dump!) and the version of stomp.py in use is logged.

Example output:
```
2019-03-06 14:03:37,150 - ssmsend - INFO - ========================================
2019-03-06 14:03:37,150 - ssmsend - INFO - Starting sending SSM version 2.3.0.
2019-03-06 14:03:37,150 - ssmsend - INFO - Retrieving broker details from ldap://lcg-bdii.cern.ch:2170 ...
2019-03-06 14:03:37,240 - ssmsend - INFO - Found 2 brokers.
2019-03-06 14:03:37,250 - ssmsend - INFO - No server certificate supplied.  Will not encrypt messages.
2019-03-06 14:03:37,319 - ssm.ssm2 - INFO - Using stomp.py version 3.1.6.
2019-03-06 14:03:37,319 - ssm.ssm2 - INFO - Established connection to mq.cro-ngi.hr, port 6162
2019-03-06 14:03:37,319 - ssm.ssm2 - INFO - Connecting using SSL...
2019-03-06 14:03:38,161 - ssm.ssm2 - ERROR - The following certificate is not authorised:  CN=bob, L=SWI, OU=PRA, O=eScience, C=UK
2019-03-06 14:03:40,160 - stomp.py - ERROR - Lost connection
2019-03-06 14:03:40,160 - ssm.ssm2 - INFO - Disconnected from broker.
2019-03-06 14:03:48,371 - ssm.ssm2 - WARNING - Failed to connect to mq.cro-ngi.hr:6162: Timed out while waiting for connection. Check the connection details.
2019-03-06 14:03:48,371 - ssm.ssm2 - INFO - Established connection to broker-prod1.argo.grnet.gr, port 6162
2019-03-06 14:03:48,371 - ssm.ssm2 - INFO - Connecting using SSL...
2019-03-06 14:03:48,871 - ssm.ssm2 - ERROR - The following certificate is not authorised:  CN=bob, L=SWI, OU=PRA, O=eScience, C=UK
2019-03-06 14:03:50,875 - stomp.py - ERROR - Lost connection
2019-03-06 14:03:50,875 - ssm.ssm2 - INFO - Disconnected from broker.
2019-03-06 14:03:59,045 - ssm.ssm2 - WARNING - Failed to connect to broker-prod1.argo.grnet.gr:6162: Timed out while waiting for connection. Check the connection details.
SSM failed to complete successfully.  See log file for details.
2019-03-06 14:03:59,045 - ssmsend - ERROR - SSM failed to complete successfully: Attempts to start the SSM failed.  The system will exit.
2019-03-06 14:03:59,045 - ssm.ssm2 - INFO - SSM connection ended.
2019-03-06 14:03:59,045 - ssmsend - INFO - SSM has shut down.
2019-03-06 14:03:59,045 - ssmsend - INFO - ========================================


```