### PR TITLE
Add basic CODEOWNERS file to simplify code reviews

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in the repo, unless a
+# later match is added and takes precedence. They will be requested for review
+# when someone opens a pull request.
+
+*    @apel/code-reviewers


### PR DESCRIPTION
This file will mean that when a pull request is opened, everyone
in the code-reviewers team will be requested for review.