### PR TITLE
Raise CryptoException if signed message verification fails (for whatever reason).

### DIFF
--- a/ssm/crypto.py
+++ b/ssm/crypto.py
@@ -179,9 +179,8 @@ def verify(signed_text, capath, check_crl):
     if "Verification successful" in error:
         log.debug(error)
     else:
-        log.warn(error)
         raise CryptoException(
-            "Failed to verify the signed message."
+            "Possible tampering. See OpenSSL error: %s" % error
         )
 
     subj = get_certificate_subject(signer)

--- a/ssm/crypto.py
+++ b/ssm/crypto.py
@@ -181,7 +181,7 @@ def verify(signed_text, capath, check_crl):
     else:
         log.warn(error)
         raise CryptoException(
-            "Failed to verify the signed message, see the log for details."
+            "Failed to verify the signed message."
         )
 
     subj = get_certificate_subject(signer)

--- a/ssm/crypto.py
+++ b/ssm/crypto.py
@@ -180,6 +180,9 @@ def verify(signed_text, capath, check_crl):
         log.debug(error)
     else:
         log.warn(error)
+        raise CryptoException(
+            "Failed to verify the signed message, see the log for details."
+        )
 
     subj = get_certificate_subject(signer)
     return body, subj
@@ -329,4 +332,3 @@ def get_signer_cert(signed_text):
         log.error(error)
 
     return certstring
-

--- a/test/test_crypto.py
+++ b/test/test_crypto.py
@@ -281,7 +281,12 @@ class TestEncryptUtils(unittest.TestCase):
         tampered_message = signed_message.replace(MSG, "Spam")
 
         # Verifying the orignal, un-tampered message should be fine.
-        verify(signed_message, TEST_CA_DIR, False)
+        verified_message, verified_signer = verify(
+            signed_message, TEST_CA_DIR, False
+        )
+        self.assertEqual(verified_message, MSG)
+        self.assertEqual(verified_signer, TEST_CERT_DN)
+
         # Verifying the tampered message should not be fine.
         self.assertRaises(
             CryptoException, verify, tampered_message, TEST_CA_DIR, False

--- a/test/test_crypto.py
+++ b/test/test_crypto.py
@@ -275,6 +275,18 @@ class TestEncryptUtils(unittest.TestCase):
         except CryptoException:
             pass
 
+    def test_message_tampering(self):
+        """Test that a tampered message is not accepted as valid."""
+        signed_message = sign(MSG, TEST_CERT_FILE, TEST_KEY_FILE)
+        tampered_message = signed_message.replace(MSG, "Spam")
+
+        # Verifying the orignal, un-tampered message should be fine.
+        verify(signed_message, TEST_CA_DIR, False)
+        # Verifying the tampered message should not be fine.
+        self.assertRaises(
+            CryptoException, verify, tampered_message, TEST_CA_DIR, False
+        )
+
 ################################################################
 # Test data below.
 ################################################################


### PR DESCRIPTION
One such reason is the message has been tampered with after being signing. Therefore this resolves #39.