### PR TITLE
Replace tabs used for code alignment with spaces

### DIFF
--- a/bin/apel-ssm
+++ b/bin/apel-ssm
@@ -19,7 +19,7 @@ start() {
     if [ $RETVAL -ne 0 ]; then
         failure;
     else
-	success;
+        success;
     fi;
     echo
     return $RETVAL
@@ -32,8 +32,8 @@ stop() {
         RETVAL=$?
         if [ $RETVAL -ne 0 ]; then
             failure;
-	else
-	    success;
+        else
+            success;
         fi;
     else
         RETVAL=1


### PR DESCRIPTION
Only touches `bin/apel-ssm`