### PR TITLE
Catch IOError in addition to OSError in AMS pull

### DIFF
--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -427,7 +427,7 @@ class Ssm2(stomp.ConnectionListener):
                 # ack ID to the list of those to be acknowledged.
                 ackids.append(msg_ack_id)
 
-            except OSError as error:
+            except (IOError, OSError) as error:
                 log.error('Failed to read or write file: %s', error)
 
         # pass list of extracted ackIds to AMS Service so that


### PR DESCRIPTION
This issue was fixed for the original style of messaging in #63 but didn't get carried over for AMS messaging. (There's a large section that should be factored out for both types of messaging to avoid issues like this!)

- Catch IOError in addition to OSError in on_message as there is no real
  difference between them and we sometimes get the former being raised.
- Rename 'error' to 'e' to match on_message convention to simplify
  refactoring later.