### PR TITLE
Limit urllib3 logging based on overall level

### DIFF
--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -169,13 +169,17 @@ class Ssm2(stomp.ConnectionListener):
                                         % (self._enc_cert, self._capath))
 
         # If the overall SSM log level is info, we want to only
-        # see log entries from stomp.py at the warning level and above.
+        # see entries from stomp.py and connectionpool at WARNING and above.
         if logging.getLogger("ssm.ssm2").getEffectiveLevel() == logging.INFO:
             logging.getLogger("stomp.py").setLevel(logging.WARNING)
+            logging.getLogger("requests.packages.urllib3.connectionpool"
+                              ).setLevel(logging.WARNING)
         # If the overall SSM log level is debug, we want to only
-        # see log entries from stomp.py at the info level and above.
+        # see entries from stomp.py and connectionpool at INFO above.
         elif logging.getLogger("ssm.ssm2").getEffectiveLevel() == logging.DEBUG:
             logging.getLogger("stomp.py").setLevel(logging.INFO)
+            logging.getLogger("requests.packages.urllib3.connectionpool"
+                              ).setLevel(logging.INFO)
 
     def set_dns(self, dn_list):
         '''


### PR DESCRIPTION
As for c8dcf5b953b7 which was included in #52, we want to limit the log spam we get from a 3rd-party module.

- Add log level setting for `connectionpool` logging, to the code that
already handles setting `stomp.py` logging, otherwise `connectionpool`
generates a lot of "Starting new HTTPS connection" messages at the
INFO level that we aren't really interested in.