### PR TITLE
Build update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,12 @@
+os: linux
 language: python
 python:
   - "2.7"
   - "3.7"
-matrix:
+jobs:
   allow_failures:
     - python: "3.7"
   fast_finish: true
-
-# Pin Ubuntu to Trusty for the moment for Python 2.6 support
-dist: trusty
 
 # Cache the dependencies installed by pip
 cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
-  - "nightly"
+  - "3.7"
 matrix:
   allow_failures:
-    - python: "nightly"
+    - python: "3.7"
   fast_finish: true
 
 # Pin Ubuntu to Trusty for the moment for Python 2.6 support

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The Python STOMP library (N.B. versions 3.1.1 and above are currently supported)
 
 The Python AMS library. See here for details on obtaining an RPM: https://github.com/ARGOeu/argo-ams-library/
 
-The Python daemon library (N.B. only versions below 2.2.0 are currently supported)
+The Python daemon library
 * `yum install python-daemon`
 
 The Python ldap library

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ The EPEL repository must be enabled.  This can be done by installing
 the RPM for your version of SL, which is available on this page:
 http://fedoraproject.org/wiki/EPEL
 
-The Python STOMP library (N.B. versions 3.1.1 and above are currently supported)
+The Python STOMP library (N.B. versions between 3.1.1 (inclusive) and 5.0.0
+(exclusive) are currently supported)
 * `yum install stomppy`
 
 The Python AMS library. See here for details on obtaining an RPM: https://github.com/ARGOeu/argo-ams-library/
@@ -90,7 +91,7 @@ Install any missing system packages needed for the SSM:
 * `apt-get -f install`
 
 Install any missing Python requirements that don't have system packages:
-* `pip install "stomp.py>=3.1.1" dirq`
+* `pip install "stomp.py<5.0.0" dirq`
 
 If you wish to run the SSM as a receiver, you will also need to install the python-daemon system package:
 * `apt-get install python-daemon`

--- a/apel-ssm.spec
+++ b/apel-ssm.spec
@@ -21,7 +21,7 @@ BuildArch:      noarch
 BuildRequires:  python-devel
 %endif
 
-Requires:       stomppy >= 3.1.1, python-daemon, python-ldap, argo-ams-library
+Requires:       stomppy < 5.0.0, python-daemon, python-ldap, argo-ams-library
 Requires(pre):  shadow-utils
 
 %define ssmconf %_sysconfdir/apel

--- a/apel-ssm.spec
+++ b/apel-ssm.spec
@@ -21,7 +21,7 @@ BuildArch:      noarch
 BuildRequires:  python-devel
 %endif
 
-Requires:       stomppy >= 3.1.1, python-daemon < 2.2.0, python-ldap, argo-ams-library
+Requires:       stomppy >= 3.1.1, python-daemon, python-ldap, argo-ams-library
 Requires(pre):  shadow-utils
 
 %define ssmconf %_sysconfdir/apel

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,5 +1,0 @@
-# Constraints that apply to pip installed requirements
-
-# coveralls dependencies that need older versions for Python 2.6
-pycparser<2.19
-idna<2.8

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,8 +1,5 @@
 # Additional requirements for the unit and coverage tests
 
-# Constraints on the requirements below
--c constraints.txt
-
 unittest2
 coveralls<=1.2.0
 mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Base requirements for ssm
 
 stomp.py>=3.1.1
-python-daemon<2.2.0
+python-daemon
 python-ldap
 # Dependencies for optional dirq based sending
 dirq

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Base requirements for ssm
 
-stomp.py>=3.1.1
+stomp.py<5.0.0
 python-daemon
 python-ldap
 # Dependencies for optional dirq based sending

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ def main():
           download_url='https://github.com/apel/ssm/releases',
           license='Apache License, Version 2.0',
           install_requires=[
-              'stomp.py>=3.1.1', 'python-ldap', 'argo-ams-library',
+              'stomp.py<5.0.0', 'python-ldap', 'argo-ams-library',
           ],
           extras_require={
               'python-daemon': ['python-daemon'],

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ def main():
               'stomp.py>=3.1.1', 'python-ldap', 'argo-ams-library',
           ],
           extras_require={
-              'python-daemon': ['python-daemon<2.2.0'],
+              'python-daemon': ['python-daemon'],
               'dirq': ['dirq'],
           },
           packages=find_packages(exclude=['bin', 'test']),


### PR DESCRIPTION
Resolves #113.

This PR removes the Python 2.6 build and the dependency version constraints that were required to maintain compatibility. It does however constrain the version of python-daemon to maintain Python 2.7 compatibility.