### PR TITLE
Drop Python 2.6, add Python 3 test compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ language: python
 python:
   - "2.7"
   - "3.7"
-jobs:
-  allow_failures:
-    - python: "3.7"
-  fast_finish: true
 
 # Cache the dependencies installed by pip
 cache: pip

--- a/bin/receiver.py
+++ b/bin/receiver.py
@@ -101,7 +101,7 @@ def main():
             set_up_logging(cp.get('logging', 'logfile'),
                            cp.get('logging', 'level'),
                            cp.getboolean('logging', 'console'))
-    except (ConfigParser.Error, ValueError, IOError), err:
+    except (ConfigParser.Error, ValueError, IOError) as err:
         print('Error configuring logging: %s' % err)
         print('SSM will exit.')
         sys.exit(1)
@@ -139,7 +139,7 @@ def main():
                 service = STOMP_SERVICE
             brokers = bg.get_broker_hosts_and_ports(service, cp.get('broker',
                                                                     'network'))
-        except ConfigParser.NoOptionError, e:
+        except ConfigParser.NoOptionError as e:
             try:
                 host = cp.get('broker', 'host')
                 port = cp.get('broker', 'port')
@@ -151,7 +151,7 @@ def main():
                 log.error('System will exit.')
                 log.info(LOG_BREAK)
                 sys.exit(1)
-        except ldap.SERVER_DOWN, e:
+        except ldap.SERVER_DOWN as e:
             log.error('Could not connect to LDAP server: %s', e)
             log.error('System will exit.')
             log.info(LOG_BREAK)
@@ -183,7 +183,7 @@ def main():
             token = cp.get('messaging', 'token')
             project = cp.get('messaging', 'ams_project')
 
-        except (ConfigParser.Error, ValueError, IOError), err:
+        except (ConfigParser.Error, ValueError, IOError) as err:
             # A token and project are needed to successfully receive from an
             # AMS instance, so log and then exit on an error.
             log.error('Error configuring AMS values: %s', err)
@@ -222,7 +222,7 @@ def main():
         dns = get_dns(options.dn_file)
         ssm.set_dns(dns)
 
-    except Exception, e:
+    except Exception as e:
         log.fatal('Failed to initialise SSM: %s', e)
         log.info(LOG_BREAK)
         sys.exit(1)
@@ -265,11 +265,11 @@ def main():
 
             i += 1
 
-    except SystemExit, e:
+    except SystemExit as e:
         log.info('Received the shutdown signal: %s', e)
         ssm.shutdown()
         dc.close()
-    except Exception, e:
+    except Exception as e:
         log.error('Unexpected exception: %s', e)
         log.error('Exception type: %s', e.__class__)
         log.error('The SSM will exit.')

--- a/bin/receiver.py
+++ b/bin/receiver.py
@@ -89,7 +89,7 @@ def main():
     # Check for pidfile
     pidfile = cp.get('daemon', 'pidfile')
     if os.path.exists(pidfile):
-        print 'Cannot start SSM.  Pidfile %s already exists.' % pidfile
+        print('Cannot start SSM.  Pidfile %s already exists.' % pidfile)
         sys.exit(1)
 
     # set up logging
@@ -101,8 +101,8 @@ def main():
                            cp.get('logging', 'level'),
                            cp.getboolean('logging', 'console'))
     except (ConfigParser.Error, ValueError, IOError), err:
-        print 'Error configuring logging: %s' % str(err)
-        print 'SSM will exit.'
+        print('Error configuring logging: %s' % err)
+        print('SSM will exit.')
         sys.exit(1)
 
     global log
@@ -174,7 +174,7 @@ def main():
                       'please check your configuration')
             log.error('System will exit.')
             log.info(LOG_BREAK)
-            print 'SSM failed to start.  See log file for details.'
+            print('SSM failed to start.  See log file for details.')
             sys.exit(1)
 
         # Attempt to configure AMS specific variables.
@@ -187,7 +187,7 @@ def main():
             # AMS instance, so log and then exit on an error.
             log.error('Error configuring AMS values: %s', err)
             log.error('SSM will exit.')
-            print 'SSM failed to start.  See log file for details.'
+            print('SSM failed to start.  See log file for details.')
             sys.exit(1)
 
     if len(brokers) == 0:

--- a/bin/receiver.py
+++ b/bin/receiver.py
@@ -34,7 +34,11 @@ import os
 import sys
 from optparse import OptionParser
 from daemon import DaemonContext
-import ConfigParser
+
+try:
+    import ConfigParser
+except ImportError:
+    import configparser as ConfigParser
 
 # How often (in seconds) to read the list of valid DNs.
 REFRESH_DNS = 600

--- a/bin/receiver.py
+++ b/bin/receiver.py
@@ -44,6 +44,7 @@ except ImportError:
 REFRESH_DNS = 600
 log = None
 
+
 def get_dns(dn_file):
     '''
     Retrieve a list of DNs from a file.

--- a/bin/receiver.py
+++ b/bin/receiver.py
@@ -18,6 +18,7 @@
 Script to run a receiving SSM.
 @author: Will Rogers
 '''
+from __future__ import print_function
 
 from ssm.brokers import StompBrokerGetter, STOMP_SERVICE, STOMP_SSL_SERVICE
 from ssm.ssm2 import Ssm2, Ssm2Exception

--- a/bin/sender.py
+++ b/bin/sender.py
@@ -30,7 +30,11 @@ import ldap
 import sys
 import os
 from optparse import OptionParser
-import ConfigParser
+
+try:
+    import ConfigParser
+except ImportError:
+    import configparser as ConfigParser
 
 
 def main():

--- a/bin/sender.py
+++ b/bin/sender.py
@@ -57,7 +57,7 @@ def main():
             set_up_logging(cp.get('logging', 'logfile'),
                            cp.get('logging', 'level'),
                            cp.getboolean('logging', 'console'))
-    except (ConfigParser.Error, ValueError, IOError), err:
+    except (ConfigParser.Error, ValueError, IOError) as err:
         print('Error configuring logging: %s' % err)
         print('The system will exit.')
         sys.exit(1)
@@ -97,7 +97,7 @@ def main():
             brokers = bg.get_broker_hosts_and_ports(service, cp.get('broker',
                                                                     'network'))
             log.info('Found %s brokers.', len(brokers))
-        except ConfigParser.NoOptionError, e:
+        except ConfigParser.NoOptionError as e:
             try:
                 host = cp.get('broker', 'host')
                 port = cp.get('broker', 'port')
@@ -110,7 +110,7 @@ def main():
                 log.info(LOG_BREAK)
                 print('SSM failed to start.  See log file for details.')
                 sys.exit(1)
-        except ldap.LDAPError, e:
+        except ldap.LDAPError as e:
             log.error('Could not connect to LDAP server: %s', e)
             log.error('System will exit.')
             log.info(LOG_BREAK)
@@ -142,7 +142,7 @@ def main():
         try:
             project = cp.get('messaging', 'ams_project')
 
-        except (ConfigParser.Error, ValueError, IOError), err:
+        except (ConfigParser.Error, ValueError, IOError) as err:
             # A project is needed to successfully send to an
             # AMS instance, so log and then exit on an error.
             log.error('Error configuring AMS values: %s', err)
@@ -152,7 +152,7 @@ def main():
 
         try:
             token = cp.get('messaging', 'token')
-        except (ConfigParser.Error, ValueError, IOError), err:
+        except (ConfigParser.Error, ValueError, IOError) as err:
             # A token is not necessarily needed, if the cert and key can be
             # used by the underlying auth system to get a suitable token.
             log.info('No AMS token provided, using cert/key pair instead.')
@@ -181,7 +181,7 @@ def main():
             destination = cp.get('messaging', 'destination')
             if destination == '':
                 raise Ssm2Exception('No destination queue is configured.')
-        except ConfigParser.NoOptionError, e:
+        except ConfigParser.NoOptionError as e:
             raise Ssm2Exception(e)
 
         # Determine what type of message store we are interacting with,
@@ -213,10 +213,10 @@ def main():
         else:
             log.info('No messages found to send.')
 
-    except (Ssm2Exception, CryptoException), e:
+    except (Ssm2Exception, CryptoException) as e:
         print('SSM failed to complete successfully.  See log file for details.')
         log.error('SSM failed to complete successfully: %s', e)
-    except Exception, e:
+    except Exception as e:
         print('SSM failed to complete successfully.  See log file for details.')
         log.error('Unexpected exception in SSM: %s', e)
         log.error('Exception type: %s', e.__class__)

--- a/bin/sender.py
+++ b/bin/sender.py
@@ -57,8 +57,8 @@ def main():
                            cp.get('logging', 'level'),
                            cp.getboolean('logging', 'console'))
     except (ConfigParser.Error, ValueError, IOError), err:
-        print 'Error configuring logging: %s' % str(err)
-        print 'The system will exit.'
+        print('Error configuring logging: %s' % err)
+        print('The system will exit.')
         sys.exit(1)
 
     log = logging.getLogger('ssmsend')
@@ -107,13 +107,13 @@ def main():
                           'Please check configuration')
                 log.error('System will exit.')
                 log.info(LOG_BREAK)
-                print 'SSM failed to start.  See log file for details.'
+                print('SSM failed to start.  See log file for details.')
                 sys.exit(1)
         except ldap.LDAPError, e:
             log.error('Could not connect to LDAP server: %s', e)
             log.error('System will exit.')
             log.info(LOG_BREAK)
-            print 'SSM failed to start.  See log file for details.'
+            print('SSM failed to start.  See log file for details.')
             sys.exit(1)
 
     elif protocol == Ssm2.AMS_MESSAGING:
@@ -134,7 +134,7 @@ def main():
                       'please check your configuration')
             log.error('System will exit.')
             log.info(LOG_BREAK)
-            print 'SSM failed to start.  See log file for details.'
+            print('SSM failed to start.  See log file for details.')
             sys.exit(1)
 
         # Attempt to configure AMS project variable.
@@ -146,7 +146,7 @@ def main():
             # AMS instance, so log and then exit on an error.
             log.error('Error configuring AMS values: %s', err)
             log.error('SSM will exit.')
-            print 'SSM failed to start.  See log file for details.'
+            print('SSM failed to start.  See log file for details.')
             sys.exit(1)
 
         try:
@@ -213,10 +213,10 @@ def main():
             log.info('No messages found to send.')
 
     except (Ssm2Exception, CryptoException), e:
-        print 'SSM failed to complete successfully.  See log file for details.'
+        print('SSM failed to complete successfully.  See log file for details.')
         log.error('SSM failed to complete successfully: %s', e)
     except Exception, e:
-        print 'SSM failed to complete successfully.  See log file for details.'
+        print('SSM failed to complete successfully.  See log file for details.')
         log.error('Unexpected exception in SSM: %s', e)
         log.error('Exception type: %s', e.__class__)
 

--- a/bin/sender.py
+++ b/bin/sender.py
@@ -18,6 +18,7 @@
 Script to run a sending SSM.
 @author: Will Rogers
 '''
+from __future__ import print_function
 
 from ssm import __version__, set_up_logging, LOG_BREAK
 from ssm.ssm2 import Ssm2, Ssm2Exception

--- a/ssm/brokers.py
+++ b/ssm/brokers.py
@@ -18,6 +18,8 @@
 Class to interact with a BDII LDAP server to retrieve information about
 the stomp brokers specified in a network.
 '''
+from __future__ import print_function
+
 import ldap
 import logging
 

--- a/ssm/brokers.py
+++ b/ssm/brokers.py
@@ -140,12 +140,12 @@ if __name__ == '__main__':
     def print_brokers(text, service, network):
         brokers = BG.get_broker_hosts_and_ports(service, network)
         # Print section heading
-        print '==', text, '=='
+        print('==', text, '==')
         # Print brokers in form 'host:port'
         for broker in brokers:
-            print '%s:%i' % (broker[0], broker[1])
+            print('%s:%i' % (broker[0], broker[1]))
         # Leave space between sections
-        print
+        print()
 
     print_brokers('SSL production brokers', STOMP_SSL_SERVICE, 'PROD')
     print_brokers('Production brokers', STOMP_SERVICE, 'PROD')

--- a/ssm/crypto.py
+++ b/ssm/crypto.py
@@ -175,6 +175,11 @@ def verify(signed_text, capath, check_crl):
         body = base64.decodestring(body)
     # otherwise, plain text
 
+    # In Python 3, decodestring() returns bytes so decode to a string while
+    # Python 2 compatability is still required.
+    if not isinstance(body, str):
+        body = body.decode()
+
     # 'openssl smime' returns "Verification successful" to standard error. We
     # don't want to log this as an error each time, but we do want to see if
     # there's a genuine error.

--- a/ssm/crypto.py
+++ b/ssm/crypto.py
@@ -319,7 +319,7 @@ def get_certificate_subject(certstring):
 
 
 def get_signer_cert(signed_text):
-    """Read the signer's certificate from the signed specified message."""
+    """Return the signer's certificate from the signed specified message."""
     # This ensures that openssl knows that the string is finished.
     # It makes no difference if the signed message is correct, but
     # prevents it from hanging in the case of an empty string.

--- a/ssm/crypto.py
+++ b/ssm/crypto.py
@@ -314,22 +314,22 @@ def get_certificate_subject(certstring):
 
 
 def get_signer_cert(signed_text):
-    '''
-    Read the signer's certificate from the signed specified message, and return the
-    certificate string.
-    '''
+    """Read the signer's certificate from the signed specified message."""
     # This ensures that openssl knows that the string is finished.
     # It makes no difference if the signed message is correct, but
     # prevents it from hanging in the case of an empty string.
     signed_text += '\n\n'
 
-    p1 = Popen(['openssl', 'smime', '-pk7out'],
-               stdin=PIPE, stdout=PIPE, stderr=PIPE)
-    p2 = Popen(['openssl', 'pkcs7', '-print_certs'],
-               stdin=p1.stdout, stdout=PIPE, stderr=PIPE)
+    p1 = Popen(['openssl', 'smime', '-pk7out'], stdin=PIPE, stdout=PIPE,
+               stderr=PIPE, universal_newlines=True)
+    pkcs7, error = p1.communicate(signed_text)
 
-    p1.stdin.write(signed_text)
-    certstring, error = p2.communicate()
+    if (error != ''):
+        log.error(error)
+
+    p2 = Popen(['openssl', 'pkcs7', '-print_certs'], stdin=PIPE, stdout=PIPE,
+               stderr=PIPE, universal_newlines=True)
+    certstring, error = p2.communicate(pkcs7)
 
     if (error != ''):
         log.error(error)

--- a/ssm/crypto.py
+++ b/ssm/crypto.py
@@ -20,6 +20,7 @@
    found that none were mature enough to implement the SMIME crypto we had
    decided on.
 '''
+from __future__ import print_function
 
 from subprocess import Popen, PIPE
 import quopri

--- a/ssm/crypto.py
+++ b/ssm/crypto.py
@@ -58,7 +58,7 @@ def check_cert_key(certpath, keypath):
     try:
         cert = _from_file(certpath)
         key = _from_file(keypath)
-    except IOError, e:
+    except IOError as e:
         log.error('Could not find cert or key file: %s', e)
         return False
 
@@ -102,7 +102,7 @@ def sign(text, certpath, keypath):
 
         return signed_msg
 
-    except OSError, e:
+    except OSError as e:
         log.error('Failed to sign message: %s', e)
         raise CryptoException('Message signing failed.  Check cert and key permissions.')
 

--- a/ssm/crypto.py
+++ b/ssm/crypto.py
@@ -67,7 +67,7 @@ def check_cert_key(certpath, keypath):
         return False
 
     p1 = Popen(['openssl', 'x509', '-noout', '-modulus'],
-               stdin=PIPE, stdout=PIPE, stderr=PIPE)
+               stdin=PIPE, stdout=PIPE, stderr=PIPE, universal_newlines=True)
     modulus1, error = p1.communicate(cert)
 
     if error != '':
@@ -75,7 +75,7 @@ def check_cert_key(certpath, keypath):
         return False
 
     p2 = Popen(['openssl', 'rsa', '-noout', '-modulus'],
-               stdin=PIPE, stdout=PIPE, stderr=PIPE)
+               stdin=PIPE, stdout=PIPE, stderr=PIPE, universal_newlines=True)
     modulus2, error = p2.communicate(key)
 
     if error != '':
@@ -93,7 +93,8 @@ def sign(text, certpath, keypath):
     '''
     try:
         p1 = Popen(['openssl', 'smime', '-sign', '-inkey', keypath, '-signer', certpath, '-text'],
-                   stdin=PIPE, stdout=PIPE, stderr=PIPE)
+                   stdin=PIPE, stdout=PIPE, stderr=PIPE,
+                   universal_newlines=True)
 
         signed_msg, error = p1.communicate(text)
 
@@ -119,7 +120,7 @@ def encrypt(text, certpath, cipher='aes128'):
     cipher = '-' + cipher
     # encrypt
     p1 = Popen(['openssl', 'smime', '-encrypt', cipher, certpath],
-               stdin=PIPE, stdout=PIPE, stderr=PIPE)
+               stdin=PIPE, stdout=PIPE, stderr=PIPE, universal_newlines=True)
 
     enc_txt, error = p1.communicate(text)
 
@@ -155,7 +156,7 @@ def verify(signed_text, capath, check_crl):
     # is verified above; this check would also check that the certificate
     # is allowed to sign with SMIME, which host certificates sometimes aren't.
     p1 = Popen(['openssl', 'smime', '-verify', '-CApath', capath, '-noverify'],
-               stdin=PIPE, stdout=PIPE, stderr=PIPE)
+               stdin=PIPE, stdout=PIPE, stderr=PIPE, universal_newlines=True)
 
     message, error = p1.communicate(signed_text)
 
@@ -206,7 +207,7 @@ def decrypt(encrypted_text, certpath, keypath):
 
     p1 = Popen(['openssl', 'smime', '-decrypt',
                 '-recip', certpath, '-inkey', keypath],
-               stdin=PIPE, stdout=PIPE, stderr=PIPE)
+               stdin=PIPE, stdout=PIPE, stderr=PIPE, universal_newlines=True)
 
     enc_txt, error = p1.communicate(encrypted_text)
 
@@ -228,7 +229,8 @@ def verify_cert_date(certpath):
     # non-zero if yes, it will expire, or zero if not.
     args = ['openssl', 'x509', '-checkend', '86400', '-noout', '-in', certpath]
 
-    p1 = Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+    p1 = Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE,
+               universal_newlines=True)
 
     message, error = p1.communicate(certpath)
 
@@ -260,7 +262,8 @@ def verify_cert(certstring, capath, check_crls=True):
     if check_crls:
         args.append('-crl_check_all')
 
-    p1 = Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+    p1 = Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE,
+               universal_newlines=True)
 
     message, error = p1.communicate(certstring)
 
@@ -298,7 +301,7 @@ def get_certificate_subject(certstring):
     Return the certificate subject's DN, in legacy openssl format.
     '''
     p1 = Popen(['openssl', 'x509', '-noout', '-subject'],
-               stdin=PIPE, stdout=PIPE, stderr=PIPE)
+               stdin=PIPE, stdout=PIPE, stderr=PIPE, universal_newlines=True)
 
     subject, error = p1.communicate(certstring)
 

--- a/ssm/message_directory.py
+++ b/ssm/message_directory.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """This module contains the MessageDirectory class."""
+from __future__ import print_function
 
 import logging
 import os

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -17,14 +17,6 @@
 '''
 from __future__ import print_function
 
-# It's possible for SSM to be used without SSL, and the ssl module isn't in the
-# standard library until 2.6, so this makes it safe for earlier Python versions.
-try:
-    import ssl
-except ImportError:
-    # ImportError is raised later on if SSL is actually requested.
-    ssl = None
-
 from ssm import crypto
 from ssm.message_directory import MessageDirectory
 
@@ -537,9 +529,6 @@ class Ssm2(stomp.ConnectionListener):
         '''
         log.info("Established connection to %s, port %i", host, port)
         if self._use_ssl:
-            if ssl is None:
-                raise ImportError("SSL connection requested but the ssl module "
-                                  "wasn't found.")
             log.info('Connecting using SSL...')
         else:
             log.warning("SSL connection not requested, your messages may be "

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -322,7 +322,7 @@ class Ssm2(stomp.ConnectionListener):
         if 'application/pkcs7-mime' in text or 'application/x-pkcs7-mime' in text:
             try:
                 text = crypto.decrypt(text, self._cert, self._key)
-            except crypto.CryptoException, e:
+            except crypto.CryptoException as e:
                 error = 'Failed to decrypt message: %s' % e
                 log.error(error)
                 return None, None, error
@@ -330,7 +330,7 @@ class Ssm2(stomp.ConnectionListener):
         # always signed
         try:
             message, signer = crypto.verify(text, self._capath, self._check_crls)
-        except crypto.CryptoException, e:
+        except crypto.CryptoException as e:
             error = 'Failed to verify message: %s' % e
             log.error(error)
             return None, None, error
@@ -435,7 +435,7 @@ class Ssm2(stomp.ConnectionListener):
                 # ack ID to the list of those to be acknowledged.
                 ackids.append(msg_ack_id)
 
-            except OSError, error:
+            except OSError as error:
                 log.error('Failed to read or write file: %s', error)
 
         # pass list of extracted ackIds to AMS Service so that
@@ -523,7 +523,7 @@ class Ssm2(stomp.ConnectionListener):
         try:
             # Remove empty dirs and unlock msgs older than 5 min (default)
             self._outq.purge()
-        except OSError, e:
+        except OSError as e:
             log.warn('OSError raised while purging message queue: %s', e)
 
     ############################################################################
@@ -573,10 +573,10 @@ class Ssm2(stomp.ConnectionListener):
             try:
                 self.start_connection()
                 break
-            except ConnectFailedException, e:
+            except ConnectFailedException as e:
                 # ConnectFailedException doesn't provide a message.
                 log.warn('Failed to connect to %s:%s.', host, port)
-            except Ssm2Exception, e:
+            except Ssm2Exception as e:
                 log.warn('Failed to connect to %s:%s: %s', host, port, e)
 
         if not self.connected:
@@ -678,7 +678,7 @@ class Ssm2(stomp.ConnectionListener):
                 f.write(str(os.getpid()))
                 f.write('\n')
                 f.close()
-            except IOError, e:
+            except IOError as e:
                 log.warn('Failed to create pidfile %s: %s', self._pidfile, e)
 
         self.handle_connect()
@@ -694,6 +694,6 @@ class Ssm2(stomp.ConnectionListener):
                     os.remove(self._pidfile)
                 else:
                     log.warn('pidfile %s not found.', self._pidfile)
-            except IOError, e:
+            except IOError as e:
                 log.warn('Failed to remove pidfile %s: %e', self._pidfile, e)
                 log.warn('SSM may not start again until it is removed.')

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -15,6 +15,7 @@
 
    @author: Will Rogers
 '''
+from __future__ import print_function
 
 # It's possible for SSM to be used without SSL, and the ssl module isn't in the
 # standard library until 2.6, so this makes it safe for earlier Python versions.

--- a/test/test_brokers.py
+++ b/test/test_brokers.py
@@ -11,6 +11,7 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
+from __future__ import print_function
 
 import unittest
 

--- a/test/test_crypto.py
+++ b/test/test_crypto.py
@@ -40,7 +40,8 @@ class TestEncryptUtils(unittest.TestCase):
         # self-signed certificate as its own CA certificate, but with its
         # name as <hash-of-subject-DN>.0.
         p1 = Popen(['openssl', 'x509', '-subject_hash', '-noout'],
-                    stdin=PIPE, stdout=PIPE, stderr=PIPE)
+                   stdin=PIPE, stdout=PIPE, stderr=PIPE,
+                   universal_newlines=True)
 
         with open(TEST_CERT_FILE, 'r') as test_cert:
             cert_string = test_cert.read()
@@ -117,7 +118,8 @@ class TestEncryptUtils(unittest.TestCase):
         # We can't use crypto.sign as that assumes the use of the '-text' option
         # which cause the message to be interpreted as plaintext
         p1 = Popen(['openssl', 'smime', '-sign', '-inkey', TEST_KEY_FILE, '-signer', TEST_CERT_FILE],
-                   stdin=PIPE, stdout=PIPE, stderr=PIPE)
+                   stdin=PIPE, stdout=PIPE, stderr=PIPE,
+                   universal_newlines=True)
 
         signed_msg2, error = p1.communicate(header_quopri_msg)
 

--- a/test/test_crypto.py
+++ b/test/test_crypto.py
@@ -106,8 +106,15 @@ class TestEncryptUtils(unittest.TestCase):
 
         # This is a manual 'fudge' to make MS2 appear like a
         # quoted-printable message when signed
-        # Encode MSG2 so it's 'quoted-printable'
-        quopri_msg = quopri.encodestring(MSG2)
+        # Encode MSG2 so it's 'quoted-printable', after encoding it to ensure
+        # it's a bytes object for Python 3. Latter is a no-op in Python 2.
+        quopri_msg = quopri.encodestring(MSG2.encode())
+
+        # In Python 3, encodestring() returns bytes so decode to a string while
+        # Python 2 compatability is still required.
+        if not isinstance(quopri_msg, str):
+            quopri_msg = quopri_msg.decode()
+
         # Add Content-Type and Content-Transfer-Encoding
         # headers to message
         header_quopri_msg = ('Content-Type: text/xml; charset=utf8\n'

--- a/test/test_crypto.py
+++ b/test/test_crypto.py
@@ -138,13 +138,13 @@ class TestEncryptUtils(unittest.TestCase):
         retrieved_msg2, retrieved_dn2 = verify(signed_msg2, TEST_CA_DIR, False)
 
         if not retrieved_dn2 == TEST_CERT_DN:
-            print retrieved_dn2
-            print TEST_CERT_DN
+            print(retrieved_dn2)
+            print(TEST_CERT_DN)
             self.fail("The DN of the verified message didn't match the cert.")
 
         if not retrieved_msg2.strip() == MSG2:
-            print retrieved_msg2
-            print MSG2
+            print(retrieved_msg2)
+            print(MSG2)
             self.fail("The verified messge didn't match the original.")
 
         # Try empty string

--- a/test/test_crypto.py
+++ b/test/test_crypto.py
@@ -1,8 +1,5 @@
-'''
-Created on 7 Dec 2011
+from __future__ import print_function
 
-@author: will
-'''
 import unittest
 import logging
 import os

--- a/test/test_crypto.py
+++ b/test/test_crypto.py
@@ -85,10 +85,10 @@ class TestEncryptUtils(unittest.TestCase):
         '''
         signed = sign(MSG, TEST_CERT_FILE, TEST_KEY_FILE)
 
-        if not 'MIME-Version' in signed:
+        if 'MIME-Version' not in signed:
             self.fail("Didn't get MIME message when signing.")
 
-        if not MSG in signed:
+        if MSG not in signed:
             self.fail('The plaintext should be included in the signed message.')
 
         # Indirect testing, using the verify_message() method
@@ -215,7 +215,7 @@ class TestEncryptUtils(unittest.TestCase):
         '''
         encrypted = encrypt(MSG, TEST_CERT_FILE)
 
-        if not 'MIME-Version' in encrypted:
+        if 'MIME-Version' not in encrypted:
             self.fail('Encrypted message is not MIME')
 
         # Indirect testing, using the decrypt_message function.

--- a/test/test_message_directory.py
+++ b/test/test_message_directory.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """This module contains test cases for the MessageDirectory class."""
+from __future__ import print_function
 
 import shutil
 import tempfile

--- a/test/test_receiver.py
+++ b/test/test_receiver.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import os
 import tempfile
 from textwrap import dedent

--- a/test/test_ssm.py
+++ b/test/test_ssm.py
@@ -80,9 +80,9 @@ class TestSsm(unittest.TestCase):
 
         # Try changing permissions on the directory we're writing to.
         # The on_message function shouldn't throw an exception.
-        os.chmod(self._msgdir, 0400)
+        os.chmod(self._msgdir, 0o0400)
         test_ssm.on_message({'nothing': 'dummy'}, 'Not signed or encrypted.')
-        os.chmod(self._msgdir, 0777)
+        os.chmod(self._msgdir, 0o0777)
 
         # Check that message with ID of 'ping' doesn't raise an exception.
         # Messages with this ID are handled differently to normal messages.

--- a/test/test_ssm.py
+++ b/test/test_ssm.py
@@ -60,7 +60,7 @@ class TestSsm(unittest.TestCase):
         try:
             shutil.rmtree(self._msgdir)
             shutil.rmtree(self._tmp_dir)
-        except OSError, e:
+        except OSError as e:
             print('Error removing temporary directory %s' % self._tmp_dir)
             print(e)
 

--- a/test/test_ssm.py
+++ b/test/test_ssm.py
@@ -65,8 +65,8 @@ class TestSsm(unittest.TestCase):
             shutil.rmtree(self._msgdir)
             shutil.rmtree(self._tmp_dir)
         except OSError, e:
-            print 'Error removing temporary directory %s' % self._tmp_dir
-            print e
+            print('Error removing temporary directory %s' % self._tmp_dir)
+            print(e)
 
     def test_on_message(self):
         '''

--- a/test/test_ssm.py
+++ b/test/test_ssm.py
@@ -1,8 +1,4 @@
-'''
-Created on 7 Dec 2011
-
-@author: will
-'''
+from __future__ import print_function
 
 import os
 import shutil

--- a/test/test_ssm.py
+++ b/test/test_ssm.py
@@ -23,18 +23,21 @@ class TestSsm(unittest.TestCase):
         # key to be files.
         key_fd, self._key_path = tempfile.mkstemp(prefix='key',
                                                   dir=self._tmp_dir)
-        os.write(key_fd, TEST_KEY)
         os.close(key_fd)
+        with open(self._key_path, 'w') as key:
+            key.write(TEST_KEY)
 
         cert_fd, self._expired_cert_path = tempfile.mkstemp(prefix='cert',
                                                             dir=self._tmp_dir)
-        os.write(cert_fd, EXPIRED_CERT)
         os.close(cert_fd)
+        with open(self._expired_cert_path, 'w') as cert:
+            cert.write(EXPIRED_CERT)
 
-        self.valid_dn_file, self.valid_dn_path = tempfile.mkstemp(
+        valid_dn_file, self.valid_dn_path = tempfile.mkstemp(
             prefix='valid', dir=self._tmp_dir)
-        os.write(self.valid_dn_file, '/test/dn')
-        os.close(self.valid_dn_file)
+        os.close(valid_dn_file)
+        with open(self.valid_dn_path, 'w') as dn:
+            dn.write('/test/dn')
 
         # Create a new certificate using the hardcoded key.
         # The subject has been hardcoded so that the generated


### PR DESCRIPTION
Partially addresses #91.

**N.B. Removes support for Python 2.6.** So we'll need to go up a major (!) version number for the next release.

This pull request adds basic Python 3 compatibility such that the Travis tests can run successfully. There are certainly other things that will need fixing to ensure SSM actually works with Python 3 (including `optparse` deprecation).

References for `quopri` changes:
[Python 2](https://docs.python.org/2/library/quopri.html)
[Python 3](https://docs.python.org/3/library/quopri.html)