### PR TITLE
Manual broker use_ssl fix

### DIFF
--- a/bin/receiver.py
+++ b/bin/receiver.py
@@ -139,14 +139,15 @@ def main():
         project = None
         token = ''
 
+        use_ssl = cp.getboolean('broker', 'use_ssl')
+        if use_ssl:
+            service = STOMP_SSL_SERVICE
+        else:
+            service = STOMP_SERVICE
+
         # If we can't get a broker to connect to, we have to give up.
         try:
             bg = StompBrokerGetter(cp.get('broker', 'bdii'))
-            use_ssl = cp.getboolean('broker', 'use_ssl')
-            if use_ssl:
-                service = STOMP_SSL_SERVICE
-            else:
-                service = STOMP_SERVICE
             brokers = bg.get_broker_hosts_and_ports(service, cp.get('broker',
                                                                     'network'))
         except ConfigParser.NoOptionError as e:

--- a/bin/receiver.py
+++ b/bin/receiver.py
@@ -94,7 +94,7 @@ def main():
 
     (options, unused_args) = op.parse_args()
 
-    cp = ConfigParser.ConfigParser()
+    cp = ConfigParser.ConfigParser({'use_ssl': 'true'})
     cp.read(options.config)
 
     # Check for pidfile

--- a/bin/sender.py
+++ b/bin/sender.py
@@ -88,16 +88,17 @@ def main():
         project = None
         token = ''
 
+        use_ssl = cp.getboolean('broker', 'use_ssl')
+        if use_ssl:
+            service = STOMP_SSL_SERVICE
+        else:
+            service = STOMP_SERVICE
+
         # If we can't get a broker to connect to, we have to give up.
         try:
             bdii_url = cp.get('broker', 'bdii')
             log.info('Retrieving broker details from %s ...', bdii_url)
             bg = StompBrokerGetter(bdii_url)
-            use_ssl = cp.getboolean('broker', 'use_ssl')
-            if use_ssl:
-                service = STOMP_SSL_SERVICE
-            else:
-                service = STOMP_SERVICE
             brokers = bg.get_broker_hosts_and_ports(service, cp.get('broker',
                                                                     'network'))
             log.info('Found %s brokers.', len(brokers))

--- a/bin/sender.py
+++ b/bin/sender.py
@@ -50,7 +50,7 @@ def main():
                         default='/etc/apel/logging.cfg')
     (options, unused_args) = op.parse_args()
 
-    cp = ConfigParser.ConfigParser()
+    cp = ConfigParser.ConfigParser({'use_ssl': 'true'})
     cp.read(options.config)
 
     # set up logging


### PR DESCRIPTION
Resolves #111.

- Move use_ssl setting outside broker catch block as `use_ssl` was only getting set if the broker was being retrieved from the BDII. If it was configured manaully, `use_ssl` wasn't set and SSM would
break. This change means it will get set either way.
- Add default True value for fetched `use_ssl` values so that there's no issue if `use_ssl` isn't set in the config files.

