### PR TITLE
Remove unittest2 and deprecated setup() arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_script:
   - export PYTHONPATH=$PYTHONPATH:`pwd -P`
   - cd test
 
-script: coverage run --branch --source=ssm,bin -m unittest2 discover --buffer
+script: coverage run --branch --source=ssm,bin -m unittest discover --buffer
 
 after_success:
   - coveralls

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,5 @@
 # Additional requirements for the unit and coverage tests
 
-unittest2
 coveralls<=1.2.0
 mock
 codecov

--- a/setup.py
+++ b/setup.py
@@ -71,21 +71,7 @@ def main():
           # We have disabled this feature so installing via the setup
           # script is similar to installing the RPM apel-ssm
           zip_safe=False,
-          # The following two settings allow the test suite
-          # to be run via 'python setup.py test'
-
-          # The test command runs the project's unit tests without
-          # actually deploying it, by temporarily putting the project's
-          # source on sys.path, after first running build_ext -i and
-          # egg_info to ensure that any C extensions and
-          # project metadata are up-to-date.
-
-          # This does require a old version of unittest to work
-          # on python2.6 (unittest2==0.5.1)
-          # The python package where the tests are located
-          test_suite='test',
-          # the test requirements
-          tests_require=['unittest2', 'mock'])
+          )
 
     # Remove temporary files with deployment names
     if 'install' in sys.argv:


### PR DESCRIPTION
- Remove unittest2 as Py 2.6 support isn't require
- Remove arguments to `setup()` related to the `test` command as this has been deprecated in the latest versions of setuptools.