### PR TITLE
95 refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The Python STOMP library (N.B. versions between 3.1.1 (inclusive) and 5.0.0
 (exclusive) are currently supported)
 * `yum install stomppy`
 
-The Python AMS library. See here for details on obtaining an RPM: https://github.com/ARGOeu/argo-ams-library/
+The Python AMS library. This is only required if you want to use AMS. See here for details on obtaining an RPM: https://github.com/ARGOeu/argo-ams-library/
 
 The Python daemon library
 * `yum install python-daemon`

--- a/apel-ssm.spec
+++ b/apel-ssm.spec
@@ -21,7 +21,7 @@ BuildArch:      noarch
 BuildRequires:  python-devel
 %endif
 
-Requires:       stomppy < 5.0.0, python-daemon, python-ldap, argo-ams-library
+Requires:       stomppy < 5.0.0, python-daemon, python-ldap
 Requires(pre):  shadow-utils
 
 %define ssmconf %_sysconfdir/apel

--- a/bin/receiver.py
+++ b/bin/receiver.py
@@ -25,7 +25,12 @@ from ssm.ssm2 import Ssm2, Ssm2Exception
 from ssm import __version__, set_up_logging, LOG_BREAK
 
 from stomp.exception import NotConnectedException
-from argo_ams_library import AmsConnectionException
+try:
+    from argo_ams_library import AmsConnectionException
+except ImportError:
+    # ImportError is raised when Ssm2 initialised if AMS is requested but lib
+    # not installed.
+    AmsConnectionException = None
 
 import time
 import logging.config

--- a/setup.py
+++ b/setup.py
@@ -51,10 +51,11 @@ def main():
           download_url='https://github.com/apel/ssm/releases',
           license='Apache License, Version 2.0',
           install_requires=[
-              'stomp.py<5.0.0', 'python-ldap', 'argo-ams-library',
+              'stomp.py<5.0.0', 'python-ldap',
           ],
           extras_require={
-              'python-daemon': ['python-daemon'],
+              'AMS': ['argo-ams-library'],
+              'daemon': ['python-daemon'],
               'dirq': ['dirq'],
           },
           packages=find_packages(exclude=['bin', 'test']),

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -36,7 +36,12 @@ import socket
 import time
 import logging
 
-from argo_ams_library import ArgoMessagingService, AmsMessage
+try:
+    from argo_ams_library import ArgoMessagingService, AmsMessage
+except ImportError:
+    # ImportError is raised later on if AMS is requested but lib not installed.
+    ArgoMessagingService = None
+    AmsMessage = None
 
 # Set up logging
 log = logging.getLogger(__name__)
@@ -100,6 +105,11 @@ class Ssm2(stomp.ConnectionListener):
         self._token = token
 
         if self._protocol == Ssm2.AMS_MESSAGING:
+            if ArgoMessagingService is None:
+                raise ImportError(
+                    "The Python package argo_ams_library must be installed to "
+                    "use AMS. Please install or use STOMP."
+                )
             self._ams = ArgoMessagingService(endpoint=self._brokers[0],
                                              token=self._token,
                                              cert=self._cert,


### PR DESCRIPTION
This resolves #95 by addressing most of the items in the issue.

- `argo-ams-library` has been made optional.
- Duplicated code between AMS and STOMP methods has been factored out to `_save_msg_to_queue`.
- AMS send message function has been factored out to `_send_msg_ams`.

It doesn't pull out AMS and STOMP functions to their own files, but that's a larger thing that is probably dependant on `stomp.py` being made optional (but it has a lot of low level integration in the code). Follow up issue in #120.