### PR TITLE
Sleep tweaks

### DIFF
--- a/bin/receiver.py
+++ b/bin/receiver.py
@@ -249,13 +249,13 @@ def main():
         # The message listening loop.
         while True:
             try:
-                time.sleep(1)
+                time.sleep(0.1)
                 if protocol == Ssm2.AMS_MESSAGING:
                     # We need to pull down messages as part of
                     # this loop when using AMS.
                     ssm.pull_msg_ams()
 
-                if i % REFRESH_DNS == 0:
+                if i % (REFRESH_DNS * 10) == 0:
                     log.info('Refreshing valid DNs and then sending ping.')
                     dns = get_dns(options.dn_file)
                     ssm.set_dns(dns)

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -485,6 +485,8 @@ class Ssm2(stomp.ConnectionListener):
                 while self._last_msg is None:
                     if not self.connected:
                         raise Ssm2Exception('Lost connection.')
+                    # Small sleep to avoid hammering the CPU
+                    time.sleep(0.01)
 
                 log_string = "Sent %s" % msgid
 
@@ -499,7 +501,6 @@ class Ssm2(stomp.ConnectionListener):
                 raise Ssm2Exception('Unknown messaging protocol: %s' %
                                     self._protocol)
 
-            time.sleep(0.1)
             # log that the message was sent
             log.info(log_string)
 


### PR DESCRIPTION
- Fix regression from 65971ae
   - The sleep was intended to limit the speed of the while loop that waited
for the STOMP message to be accepted, but this got moved outside the
while loop when AMS support was added, which does not seem sensible.
-  Speed up receiver loop
   - Speed up receiver loop by decreasing sleep as pulling a message only
once a second doesn't seem very efficient. The value of REFRESH_DNS
needs is increassed ten-fold to balance out the change in sleep.



