### PR TITLE
Add retry=3 to AMS methods for reliability

### DIFF
--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -388,7 +388,7 @@ class Ssm2(stomp.ConnectionListener):
             message = AmsMessage(data=to_send,
                                  attributes={'empaid': msgid}).dict()
 
-            argo_response = self._ams.publish(self._dest, message)
+            argo_response = self._ams.publish(self._dest, message, retry=3)
             return argo_response['messageIds'][0]
 
     def pull_msg_ams(self):
@@ -408,7 +408,8 @@ class Ssm2(stomp.ConnectionListener):
         ackids = []
 
         for msg_ack_id, msg in self._ams.pull_sub(self._listen,
-                                                  messages_to_pull):
+                                                  messages_to_pull,
+                                                  retry=3):
             # Get the AMS message id
             msgid = msg.get_msgid()
             # Get the SSM dirq id
@@ -437,7 +438,7 @@ class Ssm2(stomp.ConnectionListener):
         # it can move the offset for the next subscription pull
         # (basically acknowledging pulled messages)
         if ackids:
-            self._ams.ack_sub(self._listen, ackids)
+            self._ams.ack_sub(self._listen, ackids, retry=3)
 
     def send_ping(self):
         """Perform connection stay-alive steps.


### PR DESCRIPTION
Resolves #134.

This is backwards compatible as the AMS methods all have a **kwargs argument in the previous versions.