### PR TITLE
Hotfix 3.1.0-2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,6 @@
 Changelog for ssm
 =================
-* Tue Dev 01 2020 Adrian Coveney <adrian.coveney@stfc.ac.uk> - 3.1.0-1
+* Tue Dec 01 2020 Adrian Coveney <adrian.coveney@stfc.ac.uk> - 3.1.0-1
  - Enabled retries for all AMS communication methods to avoid timeouts from
    crashing SSM.
 

--- a/apel-ssm.spec
+++ b/apel-ssm.spec
@@ -100,7 +100,7 @@ rm -rf $RPM_BUILD_ROOT
 %doc %_defaultdocdir/%{name}
 
 %changelog
-* Tue Dev 01 2020 Adrian Coveney <adrian.coveney@stfc.ac.uk> - 3.1.0-1
+* Tue Dec 01 2020 Adrian Coveney <adrian.coveney@stfc.ac.uk> - 3.1.0-1
  - Enabled retries for all AMS communication methods to avoid timeouts from
    crashing SSM.
 


### PR DESCRIPTION
Whoops!

This PR corrects the spelling of the month in the changelogs. Merging into `master` is intentional.