### PR TITLE
Adds server and host dns to the sender log

### DIFF
--- a/bin/sender.py
+++ b/bin/sender.py
@@ -195,14 +195,14 @@ def main():
             log.info('No path type defined, assuming dirq.')
             path_type = 'dirq'
 
-        host_cert = cp.get('certificates','certificate')
+        host_cert = cp.get('certificates', 'certificate')
         host_dn = crypto.get_certificate_subject(crypto._from_file(host_cert))
         log.info('Messages will be signed using %s', host_dn)
 
         sender = Ssm2(brokers,
                       cp.get('messaging', 'path'),
                       path_type=path_type,
-                      cert=cp.get('certificates', 'certificate'),
+                      cert=host_cert,
                       key=cp.get('certificates', 'key'),
                       dest=cp.get('messaging', 'destination'),
                       use_ssl=use_ssl,

--- a/bin/sender.py
+++ b/bin/sender.py
@@ -18,7 +18,7 @@
 
 from __future__ import print_function
 
-from ssm import __version__, set_up_logging, LOG_BREAK
+from ssm import __version__, set_up_logging, LOG_BREAK, crypto
 from ssm.ssm2 import Ssm2, Ssm2Exception
 from ssm.crypto import CryptoException
 from ssm.brokers import StompBrokerGetter, STOMP_SERVICE, STOMP_SSL_SERVICE
@@ -171,6 +171,8 @@ def main():
         verify_server_cert = True
         try:
             server_cert = cp.get('certificates', 'server_cert')
+            server_dn = crypto.get_certificate_subject(crypto._from_file(server_cert))
+            log.info('Messages will be encrypted using %s', server_dn)
             try:
                 verify_server_cert = cp.getboolean('certificates', 'verify_server_cert')
             except ConfigParser.NoOptionError:
@@ -192,6 +194,10 @@ def main():
         except ConfigParser.NoOptionError:
             log.info('No path type defined, assuming dirq.')
             path_type = 'dirq'
+
+        host_cert = cp.get('certificates','certificate')
+        host_dn = crypto.get_certificate_subject(crypto._from_file(host_cert))
+        log.info('Messages will be signed using %s', host_dn)
 
         sender = Ssm2(brokers,
                       cp.get('messaging', 'path'),

--- a/bin/sender.py
+++ b/bin/sender.py
@@ -18,9 +18,9 @@
 
 from __future__ import print_function
 
-from ssm import __version__, set_up_logging, LOG_BREAK, crypto
+from ssm import __version__, set_up_logging, LOG_BREAK
 from ssm.ssm2 import Ssm2, Ssm2Exception
-from ssm.crypto import CryptoException
+from ssm.crypto import CryptoException, get_certificate_subject, _from_file
 from ssm.brokers import StompBrokerGetter, STOMP_SERVICE, STOMP_SSL_SERVICE
 
 import logging.config
@@ -171,7 +171,7 @@ def main():
         verify_server_cert = True
         try:
             server_cert = cp.get('certificates', 'server_cert')
-            server_dn = crypto.get_certificate_subject(crypto._from_file(server_cert))
+            server_dn = get_certificate_subject(_from_file(server_cert))
             log.info('Messages will be encrypted using %s', server_dn)
             try:
                 verify_server_cert = cp.getboolean('certificates', 'verify_server_cert')
@@ -196,7 +196,7 @@ def main():
             path_type = 'dirq'
 
         host_cert = cp.get('certificates', 'certificate')
-        host_dn = crypto.get_certificate_subject(crypto._from_file(host_cert))
+        host_dn = get_certificate_subject(_from_file(host_cert))
         log.info('Messages will be signed using %s', host_dn)
 
         sender = Ssm2(brokers,


### PR DESCRIPTION
Resolves #110

New log output:

```
2020-12-09 11:51:05,233 - ssmsend - INFO - Found 2 brokers.
2020-12-09 11:51:05,254 - ssmsend - INFO - Messages will be encrypted using /C=Bacon/O=Baked Beans/O=Eggs/CN=apel.server
2020-12-09 11:51:05,267 - ssmsend - INFO - Messages will be signed using /C=Bacon/O=Baked Beans/O=Eggs/CN=client.box
```