### PR TITLE
Correct topic names in AMS migrate docs

### DIFF
--- a/migrating_to_ams.md
+++ b/migrating_to_ams.md
@@ -23,8 +23,8 @@ The sender configuration is usually found under `/etc/apel/sender.cfg`. Follow t
    ```
 1. To send to the central APEL Accounting server, change `destination` to one of the following depending on your type of accounting:
    * `gLite-APEL` for Grid Accounting
-   * `eu.egi.cloud.accounting` for Cloud Accounting
-   * `eu.egi.storage.accounting` for Storage Accounting
+   * `eu-egi-cloud-accounting` for Cloud Accounting
+   * `eu-egi-storage-accounting` for Storage Accounting
 
 The next time `ssmsend` runs it should be using the AMS. You can check this by looking in the logs for a successful run, which should look like this:
 


### PR DESCRIPTION
They use dashes rather than dots.

As discovered when dealing with [this ticket](https://ggus.eu/index.php?mode=ticket_info&ticket_id=150029).