### PR TITLE
Add stomp.py DEB dependency to match other OSes

### DIFF
--- a/scripts/ssm-build-deb.sh
+++ b/scripts/ssm-build-deb.sh
@@ -54,6 +54,7 @@ fpm -s python -t deb \
 --no-auto-depends \
 --depends python2.7 \
 --depends python-pip \
+--depends 'python-stomp < 5.0.0' \
 --depends python-ldap \
 --depends libssl-dev \
 --depends libsasl2-dev \


### PR DESCRIPTION
Resolves #148 