### PR TITLE
Add openssl as dependency for rpm and deb builds

### DIFF
--- a/apel-ssm.spec
+++ b/apel-ssm.spec
@@ -21,7 +21,7 @@ BuildArch:      noarch
 BuildRequires:  python-devel
 %endif
 
-Requires:       stomppy < 5.0.0, python-daemon, python-ldap
+Requires:       stomppy < 5.0.0, python-daemon, python-ldap, openssl
 Requires(pre):  shadow-utils
 
 %define ssmconf %_sysconfdir/apel

--- a/scripts/ssm-build-deb.sh
+++ b/scripts/ssm-build-deb.sh
@@ -58,6 +58,7 @@ fpm -s python -t deb \
 --depends python-ldap \
 --depends libssl-dev \
 --depends libsasl2-dev \
+--depends openssl \
 --deb-changelog $SOURCE_DIR/ssm-$TAG/CHANGELOG \
 --python-install-bin /usr/bin \
 --python-install-lib $PYTHON_INSTALL_LIB \


### PR DESCRIPTION
Resolves #158 

openssl is a dependency of SSM, but it is called using suprocess so it's not the most obvious failure if it's not installed.

Draft while I test the build.