### PR TITLE
Specify more specific rpms for build

### DIFF
--- a/scripts/ssm-build-rpm.sh
+++ b/scripts/ssm-build-rpm.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Execute the following as root to install build tools and create a build user:
-# yum install fedora-packager
+# yum install rpmdevtools rpmlint mock
 # useradd -m rpmb
 # usermod -a -G mock rpmb
 


### PR DESCRIPTION
Not every build system will have access to fedora-packager, but only a
subset of what's included with that is actually required.