### PR TITLE
164 log the topic

### DIFF
--- a/apel-ssm.spec
+++ b/apel-ssm.spec
@@ -21,7 +21,7 @@ BuildArch:      noarch
 BuildRequires:  python-devel
 %endif
 
-Requires:       stomppy < 5.0.0, python-ldap < 3.4.0, openssl
+Requires:       stomppy < 5.0.0, python-ldap < 3.4.0, python-setuptools, openssl
 Requires(pre):  shadow-utils
 
 %define ssmconf %_sysconfdir/apel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Base requirements for ssm
 
+argo-ams-library
 stomp.py<5.0.0
 python-daemon<=2.3.0  # 2.3.1 dropped support for Python 2
 python-ldap<3.4.0  # python-ldap-3.4.0 dropped support for Python 2
@@ -7,7 +8,3 @@ setuptools  # Required for pkg_resources (also happens to be a dependency of pyt
 
 # Dependencies for optional dirq based sending
 dirq
-
-# Dependencies for experimental AMS functionality
-
-argo-ams-library

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,8 @@
 stomp.py<5.0.0
 python-daemon<=2.3.0  # 2.3.1 dropped support for Python 2
 python-ldap<3.4.0  # python-ldap-3.4.0 dropped support for Python 2
+setuptools  # Required for pkg_resources (also happens to be a dependency of python-ldap)
+
 # Dependencies for optional dirq based sending
 dirq
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ def main():
           download_url='https://github.com/apel/ssm/releases',
           license='Apache License, Version 2.0',
           install_requires=[
-              'stomp.py<5.0.0', 'python-ldap<3.4.0',
+              'stomp.py<5.0.0', 'python-ldap<3.4.0', 'setuptools',
           ],
           extras_require={
               'AMS': ['argo-ams-library'],

--- a/ssm/agents.py
+++ b/ssm/agents.py
@@ -209,7 +209,7 @@ def run_sender(protocol, brokers, project, token, cp, log):
             log.info('No server certificate supplied.  Will not encrypt messages.')
 
         # Check that the destination queue is configured and log the queue
-        destination_helper(cp, log)
+        check_destination(cp, log)
 
         # Determine what type of message store we are interacting with,
         # i.e. a dirq QueueSimple object or a plain MessageDirectory directory.
@@ -274,7 +274,7 @@ def run_receiver(protocol, brokers, project, token, cp, log, dn_file):
     log.info('The SSM will run as a daemon.')
 
     # Check that the destination queue is configured and log the queue
-    destination_helper(cp, log)
+    check_destination(cp, log)
 
     # We need to preserve the file descriptor for any log files.
     rootlog = logging.getLogger()
@@ -382,7 +382,7 @@ def get_dns(dn_file, log):
     return dns
 
 
-def destination_helper(cp, log):
+def check_destination(cp, log):
     try:
         destination = cp.get('messaging', 'destination')
         if destination == '':

--- a/ssm/agents.py
+++ b/ssm/agents.py
@@ -212,8 +212,8 @@ def run_sender(protocol, brokers, project, token, cp, log):
             destination = cp.get('messaging', 'destination')
             if destination == '':
                 raise Ssm2Exception('No destination queue is configured.')
-            else:
-                log.info('Configured destination queue: %s', destination)
+
+            log.info('Configured destination queue: %s', destination)
         except ConfigParser.NoOptionError as e:
             raise Ssm2Exception(e)
 

--- a/ssm/agents.py
+++ b/ssm/agents.py
@@ -208,14 +208,8 @@ def run_sender(protocol, brokers, project, token, cp, log):
         except ConfigParser.NoOptionError:
             log.info('No server certificate supplied.  Will not encrypt messages.')
 
-        try:
-            destination = cp.get('messaging', 'destination')
-            if destination == '':
-                raise Ssm2Exception('No destination queue is configured.')
-
-            log.info('Configured destination queue: %s', destination)
-        except ConfigParser.NoOptionError as e:
-            raise Ssm2Exception(e)
+        # Check that the destination queue is configured and log the queue
+        destination_helper(cp, log)
 
         # Determine what type of message store we are interacting with,
         # i.e. a dirq QueueSimple object or a plain MessageDirectory directory.
@@ -278,6 +272,9 @@ def run_receiver(protocol, brokers, project, token, cp, log, dn_file):
         sys.exit(1)
 
     log.info('The SSM will run as a daemon.')
+
+    # Check that the destination queue is configured and log the queue
+    destination_helper(cp, log)
 
     # We need to preserve the file descriptor for any log files.
     rootlog = logging.getLogger()
@@ -383,3 +380,14 @@ def get_dns(dn_file, log):
 
     log.debug('%s DNs found.', len(dns))
     return dns
+
+
+def destination_helper(cp, log):
+    try:
+        destination = cp.get('messaging', 'destination')
+        if destination == '':
+            raise Ssm2Exception('No destination queue is configured.')
+
+        log.info('Configured destination queue: %s', destination)
+    except ConfigParser.NoOptionError as e:
+        raise Ssm2Exception(e)

--- a/ssm/agents.py
+++ b/ssm/agents.py
@@ -212,6 +212,8 @@ def run_sender(protocol, brokers, project, token, cp, log):
             destination = cp.get('messaging', 'destination')
             if destination == '':
                 raise Ssm2Exception('No destination queue is configured.')
+            else:
+                log.info('Configured destination queue: %s', destination)
         except ConfigParser.NoOptionError as e:
             raise Ssm2Exception(e)
 

--- a/ssm/agents.py
+++ b/ssm/agents.py
@@ -388,6 +388,5 @@ def check_destination(cp, log):
         if destination == '':
             raise Ssm2Exception('No destination queue is configured.')
 
-        log.info('Configured destination queue: %s', destination)
     except ConfigParser.NoOptionError as e:
         raise Ssm2Exception(e)

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -560,10 +560,6 @@ class Ssm2(stomp.ConnectionListener):
                 log.info('Will send messages to: %s', self._dest)
 
             if self._listen is not None:
-                # Use a static ID for the subscription ID because we only ever have
-                # one subscription within a connection and ID is only considered
-                # to differentiate subscriptions within a connection.
-                self._conn.subscribe(destination=self._listen, id=1, ack='auto')
                 log.info('Subscribing to: %s', self._listen)
             return
 

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -15,6 +15,8 @@
 """
 from __future__ import print_function
 
+import pkg_resources
+
 from ssm import crypto
 from ssm.message_directory import MessageDirectory
 
@@ -549,7 +551,20 @@ class Ssm2(stomp.ConnectionListener):
         connect to each in turn until successful.
         """
         if self._protocol == Ssm2.AMS_MESSAGING:
-            log.debug('handle_connect called for AMS, doing nothing.')
+            log.info("Using AMS version %s.%s.%s.", pkg_resources.get_distribution('argo_ams_library').version)
+
+            for host, port in self._brokers:
+                log.info("Establishing connection to %s, port %i", host, port)
+
+            if self._dest is not None:
+                log.info('Will send messages to: %s', self._dest)
+
+            if self._listen is not None:
+                # Use a static ID for the subscription ID because we only ever have
+                # one subscription within a connection and ID is only considered
+                # to differentiate subscriptions within a connection.
+                self._conn.subscribe(destination=self._listen, id=1, ack='auto')
+                log.info('Subscribing to: %s', self._listen)
             return
 
         log.info("Using stomp.py version %s.%s.%s.", *stomp.__version__)

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -15,6 +15,8 @@
 """
 from __future__ import print_function
 
+import pkg_resources
+
 from ssm import crypto
 from ssm.message_directory import MessageDirectory
 
@@ -25,13 +27,6 @@ except ImportError:
     # ImportError is raised later on if dirq is requested but not installed.
     QueueSimple = None
     Queue = None
-
-try:
-    import pkg_resources
-except ImportError:
-    # pkg_resources is distributed with setuptools, but as it's only used to enhance
-    # the logging, it can be optional.
-    pkg_resources = None
 
 import stomp
 from stomp.exception import ConnectFailedException
@@ -556,9 +551,7 @@ class Ssm2(stomp.ConnectionListener):
         connect to each in turn until successful.
         """
         if self._protocol == Ssm2.AMS_MESSAGING:
-            if pkg_resources is not None:
-                # We only log the version if pkg_resources is available.
-                log.info("Using AMS version %s", pkg_resources.get_distribution('argo_ams_library').version)
+            log.info("Using AMS version %s", pkg_resources.get_distribution('argo_ams_library').version)
 
             log.info("Will connect to %s", self._brokers[0])
 

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -15,8 +15,6 @@
 """
 from __future__ import print_function
 
-import pkg_resources
-
 from ssm import crypto
 from ssm.message_directory import MessageDirectory
 
@@ -27,6 +25,13 @@ except ImportError:
     # ImportError is raised later on if dirq is requested but not installed.
     QueueSimple = None
     Queue = None
+
+try:
+    import pkg_resources
+except ImportError:
+    # pkg_resources is distributed with setuptools, but as it's only used to enhance
+    # the logging, it can be optional.
+    pkg_resources = None
 
 import stomp
 from stomp.exception import ConnectFailedException
@@ -551,7 +556,9 @@ class Ssm2(stomp.ConnectionListener):
         connect to each in turn until successful.
         """
         if self._protocol == Ssm2.AMS_MESSAGING:
-            log.info("Using AMS version %s", pkg_resources.get_distribution('argo_ams_library').version)
+            if pkg_resources is not None:
+                # We only log the version if pkg_resources is available.
+                log.info("Using AMS version %s", pkg_resources.get_distribution('argo_ams_library').version)
 
             log.info("Will connect to %s", self._brokers[0])
 

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -553,13 +553,13 @@ class Ssm2(stomp.ConnectionListener):
         if self._protocol == Ssm2.AMS_MESSAGING:
             log.info("Using AMS version %s", pkg_resources.get_distribution('argo_ams_library').version)
 
-            log.info("Establishing connection to %s", self._brokers[0])
+            log.info("Will connect to %s", self._brokers[0])
 
             if self._dest is not None:
                 log.info('Will send messages to: %s', self._dest)
 
             if self._listen is not None:
-                log.info('Subscribing to: %s', self._listen)
+                log.info('Will subscribe to: %s', self._listen)
             return
 
         log.info("Using stomp.py version %s.%s.%s.", *stomp.__version__)

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -551,10 +551,9 @@ class Ssm2(stomp.ConnectionListener):
         connect to each in turn until successful.
         """
         if self._protocol == Ssm2.AMS_MESSAGING:
-            log.info("Using AMS version %s.%s.%s.", pkg_resources.get_distribution('argo_ams_library').version)
+            log.info("Using AMS version %s", pkg_resources.get_distribution('argo_ams_library').version)
 
-            for host, port in self._brokers:
-                log.info("Establishing connection to %s, port %i", host, port)
+            log.info("Establishing connection to %s", self._brokers[0])
 
             if self._dest is not None:
                 log.info('Will send messages to: %s', self._dest)

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -551,7 +551,8 @@ class Ssm2(stomp.ConnectionListener):
         connect to each in turn until successful.
         """
         if self._protocol == Ssm2.AMS_MESSAGING:
-            log.info("Using AMS version %s", pkg_resources.get_distribution('argo_ams_library').version)
+            log.info("Using AMS version %s",
+                        pkg_resources.get_distribution('argo_ams_library').version)
 
             log.info("Will connect to %s", self._brokers[0])
 


### PR DESCRIPTION
Resolves #164

Log output for sender.py:

<pre><code>
2021-08-17 14:46:40,595 - ssmsend - INFO - ========================================
2021-08-17 14:46:40,595 - ssmsend - INFO - Starting sending SSM version 3.2.1.
2021-08-17 14:46:40,595 - ssmsend - INFO - Setting up SSM with protocol: AMS
2021-08-17 14:46:40,596 - ssmsend - INFO - No AMS token provided, using cert/key pair instead.
2021-08-17 14:46:40,596 - ssmsend - INFO - No server certificate supplied.  Will not encrypt messages.
<b>2021-08-17 14:46:40,596 - ssmsend - INFO - Configured destination queue: gLite-APEL</b>
2021-08-17 14:46:40,612 - ssmsend - INFO - Messages will be signed using /C=UK/L=Harwell/O=UKRI/OU=SCD/CN=host-172-16-113-220.nubes.stfc.ac.uk
SSM failed to complete successfully.  See log file for details.
2021-08-17 14:46:40,911 - ssmsend - ERROR - Unexpected exception in SSM: While trying the [auth_x509]: SSLError(MaxRetryError("HTTPSConnectionPool(host='msg-devel.argo.grnet.gr', port=8443): Max retries exceeded with url: /v1/service-types/ams/hosts/msg-devel.argo.grnet.gr:authx509 (Caused by SSLError(SSLError(1, u'[SSL: SSLV3_ALERT_BAD_CERTIFICATE] sslv3 alert bad certificate (_ssl.c:618)'),))",),)
2021-08-17 14:46:40,911 - ssmsend - ERROR - Exception type: <class 'argo_ams_library.amsexceptions.AmsConnectionException'>
2021-08-17 14:46:40,912 - ssmsend - INFO - SSM has shut down.
2021-08-17 14:46:40,912 - ssmsend - INFO - ========================================
</pre></code>

Log output for receiver.py:

<pre><code>
2021-08-17 14:48:04,611 - ssmreceive - INFO - ========================================
2021-08-17 14:48:04,611 - ssmreceive - INFO - Starting receiving SSM version 3.2.1.
2021-08-17 14:48:04,611 - ssmreceive - INFO - Setting up SSM with protocol: AMS
2021-08-17 14:48:04,612 - ssmreceive - INFO - No AMS token provided, using cert/key pair instead.
2021-08-17 14:48:04,612 - ssmreceive - INFO - The SSM will run as a daemon.
<b>2021-08-17 14:48:04,612 - ssmreceive - INFO - Configured destination queue: /queue/ssm2test</b>
2021-08-17 14:48:04,869 - ssmreceive - CRITICAL - Failed to initialise SSM: While trying the [auth_x509]: SSLError(MaxRetryError("HTTPSConnectionPool(host='msg-devel.argo.grnet.gr', port=8443): Max retries exceeded with url: /v1/service-types/ams/hosts/msg-devel.argo.grnet.gr:authx509 (Caused by SSLError(SSLError(1, u'[SSL: SSLV3_ALERT_BAD_CERTIFICATE] sslv3 alert bad certificate (_ssl.c:618)'),))",),)
2021-08-17 14:48:04,870 - ssmreceive - INFO - ========================================
</pre></code>

Note that for testing purposes a new certificate was used, which is what's causing the error seen in the above logs. 