### PR TITLE
Add docker build and upload image to GitHub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,55 @@
+name: Docker
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  push:
+    # Build all branches
+    branches: '*'
+    # Build tags which look like ###.###.###-###, i.e. actual releases only
+    # as any build from a GitHub tag also get's published as latest.
+    # Note: This is a GitHub actions filter pattern, not a regex
+    # (see https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet).
+    tags: [ '[0-9]+.[0-9]+.[0-9]+-[0-9]+' ]
+  pull_request:
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        # Login against a Docker registry
+        # https://github.com/docker/login-action
+        name: Login to ${{ env.REGISTRY }}
+        uses: docker/login-action@v1 
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        # Extract metadata (tags, labels) for Docker
+        # https://github.com/docker/metadata-action
+        name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      -
+        # Build and push Docker image
+        # https://github.com/docker/build-push-action
+        name: Build and push Docker image
+        uses: docker/build-push-action@v2.5.0
+        with:
+          push: true
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,6 +50,10 @@ jobs:
         name: Build and push Docker image
         uses: docker/build-push-action@v2.5.0
         with:
-          push: true
+          # Only push containers to the registry on GitHub pushes,
+          # not pull requests. GitHub won't let a rogue PR create a container
+          # in the registry without secrets being set up before hand anyway,
+          # if GitHub were to try without secrets - the action would fail.
+          push: ${{ github.event_name == 'push' }}
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
~Depends on #193, this PR will need to be rebased once that has been merged.~

Builds a container on a pull request or on a push of either any branch or a tag matching a "proper" release of the SSM (not a release candidate or other tagged version.

When it builds a tag, if the build was done in the main repository, the resultant image will also get pushed to  container registry with the `lastest` tag (which is why we only build proper releases of the SSM).