### PR TITLE
Cap python-ldap below 3.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 
 stomp.py<5.0.0
 python-daemon
-python-ldap<3.4.0
+python-ldap<3.4.0  # python-ldap-3.4.0 dropped support for Python 2
 # Dependencies for optional dirq based sending
 dirq
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 
 stomp.py<5.0.0
 python-daemon
-python-ldap
+python-ldap<3.4.0
 # Dependencies for optional dirq based sending
 dirq
 


### PR DESCRIPTION
python-ldap-3.4.0 dropped support for Python 2: https://github.com/python-ldap/python-ldap/releases/tag/python-ldap-3.4.0