### PR TITLE
Set GH Action unit test matrix to not fail fast

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -6,6 +6,7 @@ jobs:
   unit-test:
     runs-on: ubuntu-18.04
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['2.x', '3.x']
     name: Python ${{ matrix.python-version }} test


### PR DESCRIPTION
- This means that every job will run, whatever the result of any other.