### PR TITLE
[GT-152] timeout causes ssm to crash

### DIFF
--- a/ssm/agents.py
+++ b/ssm/agents.py
@@ -37,7 +37,8 @@ except ImportError:
 
 from stomp.exception import NotConnectedException
 try:
-    from argo_ams_library import AmsConnectionException
+    from argo_ams_library import (AmsConnectionException, AmsTimeoutException,
+                                  AmsBalancerException)
 except ImportError:
     # ImportError is raised when Ssm2 initialised if AMS is requested but lib
     # not installed.
@@ -328,7 +329,9 @@ def run_receiver(protocol, brokers, project, token, cp, log, dn_file):
                     if protocol == Ssm2.STOMP_MESSAGING:
                         ssm.send_ping()
 
-            except (NotConnectedException, AmsConnectionException) as error:
+            except (NotConnectedException, AmsConnectionException,
+                    AmsTimeoutException, AmsBalancerException) as error:
+
                 log.warning('Connection lost.')
                 log.debug(error)
                 ssm.shutdown()


### PR DESCRIPTION
When we make use of `AmsHttpRequests`  provided by the AMS itself, `pull_sub.` is a POST request and it under the hood uses `_retry_make_request()` where it tries to make an attempt for retries. 

In our case, retry =3:
If enabled (retry > 0), multiple subscription pulls will be tried in case of problems/glitches with the AMS service. 

Because we are using the `ArgoMessagingService` class under the hood, it is making use of `requests`  lib. So timeouts (one of the API error status, requests.exceptions.ReadTimeout) from AMS (HTTP 408) or load balancer (HTTP 408 and 504) should be handled by `AmsBalancerException,` `AmsConnectionException,` `AmsTimeoutException.`


Resolves #214 .