### PR TITLE
[GT-151] - Action jobs should be disabled in non-upstream repos

### DIFF
--- a/.github/workflows/build-pkgs.yml
+++ b/.github/workflows/build-pkgs.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   build-rpm:
     runs-on: ubuntu-latest
+    if: '!github.event.repository.fork'
+
     env:
       # _github_home is the dir used as a volume by the container
       RPMDIR: /home/runner/work/_temp/_github_home/rpmbuild

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,6 +19,8 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    if: '!github.event.repository.fork'
+
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
The condition given to `cron` JOB helps us to NOT trigger the event in a fork branches. And, It will only trigger the CRON Job if it is DEV branch.

"Resolves #211"