### PR TITLE
Revert "Pin to Ubuntu 18.04"

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   unit-test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This reverts commit c9994b48dda2b951781afc078c7c96c82136a796.

Ubuntu 18 is no longer available in GH Actions, and also we want to see the failing tests due to the OpenSSL changes. See https://github.com/apel/ssm/pull/166#issuecomment-867761508.

(No, I've no idea why I did pin the version previously, going counter to that linked comment.)