### PR TITLE
Minor timeout changes

### DIFF
--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -390,7 +390,7 @@ class Ssm2(stomp.ConnectionListener):
             message = AmsMessage(data=to_send,
                                  attributes={'empaid': msgid}).dict()
 
-            argo_response = self._ams.publish(self._dest, message, retry=3)
+            argo_response = self._ams.publish(self._dest, message, retry=3, timeout=10)
             return argo_response['messageIds'][0]
         else:
             # We ignore empty messages as there is no point sending them.
@@ -415,7 +415,8 @@ class Ssm2(stomp.ConnectionListener):
 
         for msg_ack_id, msg in self._ams.pull_sub(self._listen,
                                                   messages_to_pull,
-                                                  retry=3):
+                                                  retry=3,
+                                                  timeout=10):
             # Get the AMS message id
             msgid = msg.get_msgid()
             # Get the SSM dirq id
@@ -444,7 +445,7 @@ class Ssm2(stomp.ConnectionListener):
         # it can move the offset for the next subscription pull
         # (basically acknowledging pulled messages)
         if ackids:
-            self._ams.ack_sub(self._listen, ackids, retry=3)
+            self._ams.ack_sub(self._listen, ackids, retry=3, timeout=10)
 
     def send_ping(self):
         """Perform connection stay-alive steps.


### PR DESCRIPTION
Resolves #243

Adding timeouts to resolve issue #243 - currently set to 10 second timeouts.  

Difficult to consistently unit test for, so manual testing was done by blocking the TCP connection through TCPKill and sending Fallocate-d 512kb messages through and watching the TCP traffic.  Timeouts successfully call the underlying requests library, and no longer indefinitely looks for a connection.  Tested on a scientific Linux 7 distro running python 3.6.8 and 2.7.5.