### PR TITLE
Cap version of certifi used below 2020.4.5.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Base requirements for ssm
 
 argo-ams-library
+certifi<2020.4.5.2 # Used by AMS (via requests), 2020.4.5.2 dropped support for Python 2
 stomp.py<5.0.0
 python-daemon<=2.3.0  # 2.3.1 dropped support for Python 2
 python-ldap<3.4.0  # python-ldap-3.4.0 dropped support for Python 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Base requirements for ssm
 
 argo-ams-library
-certifi<2020.4.5.2 # Used by AMS (via requests), 2020.4.5.2 dropped support for Python 2
+certifi<2020.4.5.2  # Used by AMS (via requests), 2020.4.5.2 dropped support for Python 2
 stomp.py<5.0.0
 python-daemon<=2.3.0  # 2.3.1 dropped support for Python 2
 python-ldap<3.4.0  # python-ldap-3.4.0 dropped support for Python 2


### PR DESCRIPTION
Resolves #257 

- 2020.4.5.2 dropped Python 2 support, https://github.com/certifi/python-certifi/commit/5efdd48f719d9c3c7c8f9a812da2256d088eab78
- `certifi` is used by `requests`, which is used by `argo-ams-library`

This resolves the syntax error shown in the issue and I have tested the SSM to the point where the ARGO Messaging Service says my dev environment isn't authorised to sent messages.