### PR TITLE
String/Bytes fix

### DIFF
--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -318,6 +318,13 @@ class Ssm2(stomp.ConnectionListener):
 
     def _save_msg_to_queue(self, body, empaid):
         """Extract message contents and add to the accept or reject queue."""
+        try:
+            # if not bytes will fail with "'str' obj has no attribute decode"
+            body = body.decode('utf-8')
+        except (AttributeError):
+            # Message type is something string related
+            pass
+
         extracted_msg, signer, err_msg = self._handle_msg(body)
         try:
             # If the message is empty or the error message is not empty
@@ -332,7 +339,6 @@ class Ssm2(stomp.ConnectionListener):
                     body = extracted_msg
 
                 log.warning("Message rejected: %s", err_msg)
-
                 name = self._rejectq.add({'body': body,
                                           'signer': signer,
                                           'empaid': empaid,

--- a/test/test_ssm.py
+++ b/test/test_ssm.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import print_function
 
 import os
@@ -92,6 +93,15 @@ class TestSsm(unittest.TestCase):
         test_ssm.on_message({'empa-id': 'ping'}, 'body')
         # Check that msg with ID and no real content doesn't raise exception.
         test_ssm.on_message({'empa-id': '012345'}, 'body')
+
+    def test_str_bytes_outgoing(self):
+        """Test to ensure that outgoing messages are converted from Bytes to Str"""
+        test_ssm = Ssm2(self._brokers, self._msgdir, TEST_CERT_FILE,
+                        self._key_path, dest=self._dest, listen=self._listen)
+
+        message = "Appelle Hippocampéléphantocamélos"
+        byte_message = message.encode()
+        test_ssm.on_message({'empa-id': '012345'}, byte_message)
 
     def test_init_expired_cert(self):
         """Test right exception is thrown creating an SSM with expired cert."""


### PR DESCRIPTION
Resolves #146
Resolves #209 

The PR adds a new test which sends bytestrings through on_message, and through the test isolated two different issues with bytestring handling:

```
 if 'application/pkcs7-mime' in text or 'application/x-pkcs7-mime' in text:
            try:
                text = crypto.decrypt(text, self._cert, self._key)
            except crypto.CryptoException as e:
                error = 'Failed to decrypt message: %s' % e
                log.error(error)
                return None, None, error
```
In _handle_msg, the string comparison with 'in' would trigger a byte-not-str error,
```
 log.warning("Message rejected: %s", err_msg)
 name = self._rejectq.add({'body': body,
                                          'signer': signer,
                                          'empaid': empaid,
                                          'error': err_msg})
 log.info("Message saved to reject queue as %s", name)
```
In _save_msg_to_queue, errors would be caught by the IO/OS error handler, but removing that showed that the raw bytestring from 'body' was being placed into Dirq which handled it as if it was a string causing a decode error.

Our Dirq schemas suggest that we only want strings in this point.  I added a ducktype test that solves both problems in _save_msg_to_queue.