### PR TITLE
OpenSSL compatibility fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ RUN yum -y install python-pip
 # Install the system requirements of python-ldap
 RUN yum -y install gcc python-devel openldap-devel
 
+# Install libffi, a requirement of openssl
+RUN yum -y install libffi-devel
+
 # Install the system requirements of ssm
 RUN yum -y install openssl
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,18 +7,18 @@ COPY . /tmp/ssm
 WORKDIR /tmp/ssm
 
 # Add the EPEL repo so we can get pip
-RUN yum -y install epel-release
+RUN yum -y install epel-release && yum clean all
 # Then get pip
-RUN yum -y install python-pip
+RUN yum -y install python-pip && yum clean all
 
 # Install the system requirements of python-ldap
-RUN yum -y install gcc python-devel openldap-devel
+RUN yum -y install gcc python-devel openldap-devel && yum clean all
 
 # Install libffi, a requirement of openssl
-RUN yum -y install libffi-devel
+RUN yum -y install libffi-devel && yum clean all
 
 # Install the system requirements of ssm
-RUN yum -y install openssl
+RUN yum -y install openssl && yum clean all
 
 # Install the python requirements of SSM
 RUN pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,8 @@
 
 argo-ams-library
 certifi<2020.4.5.2  # Used by AMS (via requests), 2020.4.5.2 dropped support for Python 2
+pyOpenSSL<=21.0.0 # 22.0.0 dropped support for Python 2
+cryptography==3.3.0 # Crypto dropped support for Python 2 after 3.3.  They're now on 41.X...
 stomp.py<5.0.0
 python-daemon<=2.3.0  # 2.3.1 dropped support for Python 2
 python-ldap<3.4.0  # python-ldap-3.4.0 dropped support for Python 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@
 
 argo-ams-library
 certifi<2020.4.5.2  # Used by AMS (via requests), 2020.4.5.2 dropped support for Python 2
-pyOpenSSL<=21.0.0 # 22.0.0 dropped support for Python 2
-cryptography==3.3.0 # Crypto dropped support for Python 2 after 3.3.  They're now on 41.X...
+pyopenssl<=21.0.0  # 22.0.0 dropped support for Python 2
+cryptography==3.3.0  # Crypto dropped support for Python 2 after 3.3.  They're now on 41.X...
 stomp.py<5.0.0
 python-daemon<=2.3.0  # 2.3.1 dropped support for Python 2
 python-ldap<3.4.0  # python-ldap-3.4.0 dropped support for Python 2

--- a/ssm/crypto.py
+++ b/ssm/crypto.py
@@ -299,22 +299,22 @@ def verify_cert_path(certpath, capath, check_crls=True):
 
 def get_subject_components(subject_x509name):
     """RegEx to strip a keyname into a separated list."""
-    subject = "".join("/{:s}={:s}".format(name.decode(), value.decode())
-                      for name, value in subject_x509name.get_components())
-
+    subject = "".join(
+        "/{:s}={:s}".format(name.decode(), value.decode())
+        for name, value in subject_x509name.get_components()
+    )
     return subject
 
 def get_certificate_subject(certstring):
     """Return the certificate subject's DN, in legacy openssl format.
 
-    In 3.4.0, this was updated to use PyOpenSSL to maintain compatibility with
+    This was updated to use PyOpenSSL to maintain compatibility with
     Python 3.6 and later versions, along with OpenSSL 1.0.2 and 1.1.1.
     """
     try:
         subject_x509name = OpenSSL.crypto.load_certificate(
-            type=OpenSSL.crypto.FILETYPE_PEM,
-            buffer=certstring
-            ).get_subject()
+            type=OpenSSL.crypto.FILETYPE_PEM, buffer=certstring
+        ).get_subject()
     except Exception as error:
         log.error(error)
         raise CryptoException(error)

--- a/ssm/crypto.py
+++ b/ssm/crypto.py
@@ -22,11 +22,12 @@
 """
 from __future__ import print_function
 
-from subprocess import Popen, PIPE
-import OpenSSL
-import quopri
 import base64
 import logging
+import OpenSSL
+import quopri
+from subprocess import Popen, PIPE
+
 
 # logging configuration
 log = logging.getLogger(__name__)

--- a/ssm/crypto.py
+++ b/ssm/crypto.py
@@ -23,6 +23,7 @@
 from __future__ import print_function
 
 from subprocess import Popen, PIPE
+import OpenSSL
 import quopri
 import base64
 import logging
@@ -295,20 +296,30 @@ def verify_cert_path(certpath, capath, check_crls=True):
     certstring = _from_file(certpath)
     return verify_cert(certstring, capath, check_crls)
 
+def get_subject_components(subject_x509name):
+
+    # Undergoing testing
+    subject = "".join("/{:s}={:s}".format(name.decode(), value.decode())
+                      for name, value in subject_x509name.get_components())
+
+    return subject
 
 def get_certificate_subject(certstring):
-    """Return the certificate subject's DN, in legacy openssl format."""
-    p1 = Popen(['openssl', 'x509', '-noout', '-subject'],
-               stdin=PIPE, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+    """Return the certificate subject's DN, in legacy openssl format.
 
-    subject, error = p1.communicate(certstring)
-
-    if (error != ''):
+    In 3.4.0, this was updated to use PyOpenSSL to maintain compatibility with
+    Python 3.6 and later versions, along with OpenSSL 1.0.2 and 1.1.1.
+    """
+    try:
+        subject_x509name = OpenSSL.crypto.load_certificate(
+            type=OpenSSL.crypto.FILETYPE_PEM,
+            buffer=certstring
+            ).get_subject()
+    except Exception as error:
         log.error(error)
-        raise CryptoException('Failed to get subject: %s' % error)
+        raise CryptoException(error)
 
-    subject = subject.strip()[9:]  # remove 'subject= ' from the front
-    return subject
+    return get_subject_components(subject_x509name)
 
 
 def get_signer_cert(signed_text):

--- a/ssm/crypto.py
+++ b/ssm/crypto.py
@@ -297,7 +297,7 @@ def verify_cert_path(certpath, capath, check_crls=True):
     certstring = _from_file(certpath)
     return verify_cert(certstring, capath, check_crls)
 
-def get_subject_components(subject_x509name):
+def _get_subject_components(subject_x509name):
     """RegEx to strip a keyname into a separated list."""
     subject = "".join(
         "/{:s}={:s}".format(name.decode(), value.decode())
@@ -319,7 +319,7 @@ def get_certificate_subject(certstring):
         log.error(error)
         raise CryptoException(error)
 
-    return get_subject_components(subject_x509name)
+    return _get_subject_components(subject_x509name)
 
 
 def get_signer_cert(signed_text):

--- a/ssm/crypto.py
+++ b/ssm/crypto.py
@@ -297,8 +297,7 @@ def verify_cert_path(certpath, capath, check_crls=True):
     return verify_cert(certstring, capath, check_crls)
 
 def get_subject_components(subject_x509name):
-
-    # Undergoing testing
+    """RegEx to strip a keyname into a separated list."""
     subject = "".join("/{:s}={:s}".format(name.decode(), value.decode())
                       for name, value in subject_x509name.get_components())
 

--- a/test/test_crypto.py
+++ b/test/test_crypto.py
@@ -1,23 +1,25 @@
 from __future__ import print_function
 
-import unittest
 import logging
-import os
 import OpenSSL
+import os
+import quopri
 from subprocess import call, Popen, PIPE
 import tempfile
-import quopri
+import unittest
 
-from ssm.crypto import check_cert_key, \
-    get_certificate_subject, \
-    get_signer_cert, \
-    sign, \
-    encrypt, \
-    decrypt, \
-    verify, \
-    verify_cert, \
-    get_subject_components, \
+from ssm.crypto import (check_cert_key,
+    get_certificate_subject,
+    get_signer_cert,
+    sign,
+    encrypt,
+    decrypt,
+    verify,
+    verify_cert,
+    get_subject_components,
     CryptoException
+)
+
 
 logging.basicConfig()
 

--- a/test/test_crypto.py
+++ b/test/test_crypto.py
@@ -16,7 +16,7 @@ from ssm.crypto import (check_cert_key,
     decrypt,
     verify,
     verify_cert,
-    get_subject_components,
+    _get_subject_components,
     CryptoException
 )
 
@@ -186,7 +186,7 @@ class TestEncryptUtils(unittest.TestCase):
                 OpenSSL.crypto.FILETYPE_PEM, cert_string
         ).get_subject()
 
-        self.assertEqual(get_subject_components(subject_x509name), TEST_CERT_DN,
+        self.assertEqual(_get_subject_components(subject_x509name), TEST_CERT_DN,
                          msg="Didn't retrieve correct DN from cert.")
 
     def test_get_certificate_subject(self):

--- a/test/test_crypto.py
+++ b/test/test_crypto.py
@@ -177,20 +177,17 @@ class TestEncryptUtils(unittest.TestCase):
         self.assertRaises(CryptoException, verify, None, 'not a path', False)
 
     def test_get_subject_components(self):
-        '''
-        Check that the correct DN is extracted from the certstring.
-        '''
+        """Check that the correct DN is extracted from the certstring."""
         # Still a valid certificate
         with open(TEST_CERT_FILE, 'r') as test_cert:
             cert_string = test_cert.read()
 
         subject_x509name = OpenSSL.crypto.load_certificate(
-            OpenSSL.crypto.FILETYPE_PEM,
-            cert_string
-            ).get_subject()
+                OpenSSL.crypto.FILETYPE_PEM, cert_string
+        ).get_subject()
 
-        if not get_subject_components(subject_x509name) == TEST_CERT_DN:
-            self.fail("Didn't retrieve correct DN from cert.")
+        self.assertEqual(get_subject_components(subject_x509name), TEST_CERT_DN,
+                         msg="Didn't retrieve correct DN from cert.")
 
     def test_get_certificate_subject(self):
         '''

--- a/test/test_crypto.py
+++ b/test/test_crypto.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import unittest
 import logging
 import os
+import OpenSSL
 from subprocess import call, Popen, PIPE
 import tempfile
 import quopri
@@ -15,6 +16,7 @@ from ssm.crypto import check_cert_key, \
     decrypt, \
     verify, \
     verify_cert, \
+    get_subject_components, \
     CryptoException
 
 logging.basicConfig()
@@ -171,6 +173,22 @@ class TestEncryptUtils(unittest.TestCase):
         # Try None arguments
         self.assertRaises(CryptoException, verify, 'Bibbly bobbly', None, False)
         self.assertRaises(CryptoException, verify, None, 'not a path', False)
+
+    def test_get_subject_components(self):
+        '''
+        Check that the correct DN is extracted from the certstring.
+        '''
+        # Still a valid certificate
+        with open(TEST_CERT_FILE, 'r') as test_cert:
+            cert_string = test_cert.read()
+
+        subject_x509name = OpenSSL.crypto.load_certificate(
+            OpenSSL.crypto.FILETYPE_PEM,
+            cert_string
+            ).get_subject()
+
+        if not get_subject_components(subject_x509name) == TEST_CERT_DN:
+            self.fail("Didn't retrieve correct DN from cert.")
 
     def test_get_certificate_subject(self):
         '''


### PR DESCRIPTION
Resolves #167 

At @jrha 's suggestion, to solve a formatting conflict, this PR adds pyOpenSSL as a dependency and uses it to handle the distinguished name formatting.  pyOpenSSL isn't currently used for anything else.