### PR TITLE
FPM build script for RPM and DEB

### DIFF
--- a/scripts/ssm-build-dual.sh
+++ b/scripts/ssm-build-dual.sh
@@ -14,14 +14,14 @@
 
 set -e
 
-usage() { 
+usage() {
     echo "Usage: $0 [options] (deb | rpm) <version> <iteration> <python_root_dir> "
     echo -e "Build script for Apel-SSM.\n"
     echo "  -h                    Displays help."
     echo "  -v                    Verbose FPM output."
-    echo "  -s <source_dir>       Directory of source files.  Defaults to /debbuild/source or SOME RPM DIR." 
+    echo "  -s <source_dir>       Directory of source files.  Defaults to /debbuild/source or SOME RPM DIR."
     echo -e "  -b <build_dir>        Directory of build files.  Defaults to /debbuild/build or SOME RPM DIR.\n" 1>&2;
-    exit 1; 
+    exit 1;
 }
 
 # Bool flags to prevent automatic overwrite of input
@@ -62,7 +62,7 @@ ITERATION=$3
 PYTHON_ROOT_DIR=$4 # i.e. /usr/lib/python3.6
 
 # Alter library, build and source directories depending on the package
-if [[ "$PACK_TYPE" = "deb" ]]; then 
+if [[ "$PACK_TYPE" = "deb" ]]; then
     LIB_EXTENSION="/dist-packages"
     if [[ "$SOURCE_ASSIGNED" = 0 ]]; then
         SOURCE_DIR=~/debbuild/source
@@ -136,7 +136,7 @@ elif [[ ${PY_NUM:0:1} == "2" ]]; then
         --depends python-ldap \
         --depends libssl-dev \
         --depends libsasl2-dev \
-        --depends openssl " 
+        --depends openssl "
 fi
 
 # python-bin must always be specified in modern linux

--- a/scripts/ssm-build-dual.sh
+++ b/scripts/ssm-build-dual.sh
@@ -15,7 +15,7 @@
 set -e
 
 usage() { 
-    echo "[options] Usage: $0 (deb | rpm) <version> <iteration> <python_root_dir> "
+    echo "Usage: $0 [options] (deb | rpm) <version> <iteration> <python_root_dir> "
     echo -e "Build script for Apel-SSM.\n"
     echo "  -h                    Displays help."
     echo "  -v                    Verbose FPM output."
@@ -42,8 +42,7 @@ while getopts ":hs:b:v" o; do
             BUILD_DIR=$b
             BUILD_ASSIGNED=1
             ;;
-        v)  v=${OPTARG}
-            VERBOSE="--verbose "
+        v)  VERBOSE="--verbose "
             ;;
         *)  usage;
             ;;
@@ -86,24 +85,23 @@ fi
 
 # Directory cleaning and repository management
 # Create SSM and DEB dir (if not present)
-mkdir -p $SOURCE_DIR
-mkdir -p $BUILD_DIR
+mkdir -p "$SOURCE_DIR"
+mkdir -p "$BUILD_DIR"
 
 # Clean up any previous build
-rm -rf $SOURCE_DIR/*
-rm -rf $BUILD_DIR/*
+rm -rf "${SOURCE_DIR:?}"/*
+rm -rf "${BUILD_DIR:?}"/*
 
 # Get and extract the source
 TAR_FILE=${VERSION}-${ITERATION}.tar.gz
 TAR_URL=https://github.com/apel/ssm/archive/$TAR_FILE
-wget --no-check-certificate $TAR_URL -O $TAR_FILE
-tar xvf $TAR_FILE -C $SOURCE_DIR
-rm -f $TAR_FILE
+wget --no-check-certificate "$TAR_URL" -O "$TAR_FILE"
+tar xvf "$TAR_FILE" -C "$SOURCE_DIR"
+rm -f "$TAR_FILE"
 
 # Get supplied Python version
-PY_VERSION=$(basename $PYTHON_ROOT_DIR)
+PY_VERSION="$(basename "$PYTHON_ROOT_DIR")"
 PY_NUM=${PY_VERSION#python}
-echo $PY_NUM
 
 # Universal FPM Call
 FPM_CORE="fpm -s python \
@@ -154,14 +152,14 @@ BUILD_PACKAGE_COMMAND=${FPM_CORE}${FPM_PYTHON}${VERBOSE}${PACKAGE_VERSION}
 eval "$BUILD_PACKAGE_COMMAND"
 
 # When installed, use pleaserun to perform system specific service setup
-fpm -s pleaserun -t $PACK_TYPE \
+fpm -s pleaserun -t "$PACK_TYPE" \
 -n apel-ssm-service \
--v $VERSION \
---iteration $ITERATION \
+-v "$VERSION" \
+--iteration "$ITERATION" \
 -m "Apel Administrators <apel-admins@stfc.ac.uk>" \
 --description "Secure Stomp Messenger (SSM) Service Daemon files." \
 --architecture all \
 --no-auto-depends \
 --depends apel-ssm \
---package $BUILD_DIR \
+--package "$BUILD_DIR" \
 /usr/bin/ssmreceive

--- a/scripts/ssm-build-dual.sh
+++ b/scripts/ssm-build-dual.sh
@@ -4,7 +4,9 @@
 # Adapted from the Debian only build script, now with RPM!
 # @Author: Nicholas Whyatt (RedProkofiev@github.com)
 
-set -e
+# Script runs well with FPM 1.14.2 on ruby 2.7.1, setuptools 51.3.3 on RHEL and Deb platforms
+
+set -ex
 
 usage() { 
     echo "Usage: $0 (deb | rpm) <version> <iteration> <python_root_dir> [options]"
@@ -16,17 +18,11 @@ usage() {
     exit 1; 
 }
 
-# cheap python hack!
-# if ! python3 -c 'import sys; assert sys.version_info >= (3,6)' > /dev/null; then
-#     export PYTHON_VERSION=`python -c 'import sys; version=sys.version_info[:3]; print("{0}.{1}".format(*version))'
-# elif ! python2 -c 'import sys; assert sys.version_info >= (3,6)' > /dev/null; then
-
 SOURCE_ASSIGNED=0
 BUILD_ASSIGNED=0
-BIN_DIR="/usr/bin/python3.8 " \
 
 # Configurable options
-while getopts ":hs:b:v:e" o; do
+while getopts ":hs:b:v" o; do
     case "${o}" in
         h)  echo "SSM Help"
             usage;
@@ -40,10 +36,7 @@ while getopts ":hs:b:v:e" o; do
             BUILD_ASSIGNED=1
             ;;
         v)  v=${OPTARG}
-            VERBOSE="--verbose " \
-            ;;
-        e)  e=${OPTARG}
-            BIN_DIR="$b " \
+            VERBOSE="--verbose "
             ;;
         *)  usage;
             ;;
@@ -62,9 +55,6 @@ VERSION=$2
 ITERATION=$3
 PYTHON_ROOT_DIR=$4 # i.e. /usr/lib/python3.6
 
-# TODO: Replace rpm directories with their sensible equivalents
-# It ain't pretty, but it is readable and it gets the job done
-# LIB_EXTENSION is the install dir for python lib files, and is system dependent
 if [[ "$PACK_TYPE" = "deb" ]]; then 
     LIB_EXTENSION="/dist-packages"
     if [[ "$SOURCE_ASSIGNED" = 0 ]]; then
@@ -86,7 +76,6 @@ else # If package type is neither deb nor rpm, show an error message and exit
     usage;
 fi
 
-
 # Directory cleaning and repository management
 # Create SSM and DEB dir (if not present)
 mkdir -p $SOURCE_DIR
@@ -98,7 +87,7 @@ rm -rf $BUILD_DIR/*
 
 # Get and extract the source
 TAR_FILE=${VERSION}-${ITERATION}.tar.gz
-TAR_URL=https://github.com/apel/ssm/archive/$TAR_FILE
+TAR_URL=https://github.com/RedProkofiev/ssm/archive/$TAR_FILE
 wget --no-check-certificate $TAR_URL -O $TAR_FILE
 tar xvf $TAR_FILE -C $SOURCE_DIR
 rm -f $TAR_FILE
@@ -108,23 +97,30 @@ PY_VERSION=$(basename $PYTHON_ROOT_DIR)
 PY_NUM=${PY_VERSION#python}
 echo $PY_NUM
 
-
 # Universal FPM Call
-FPM_CORE="fpm -s python -t $PACK_TYPE \
+FPM_CORE="fpm -s python \
+    -t $PACK_TYPE \
     -n apel-ssm \
     -v $VERSION \
     --iteration $ITERATION \
     -m \"Apel Administrators <apel-admins@stfc.ac.uk>\" \
     --description \"Secure Stomp Messenger (SSM).\" \
-    --no-auto-depends " \
+    --no-auto-depends "
 
+if [[ ${PY_NUM:0:1} == "3" ]]; then
+    echo "Building $VERSION iteration $ITERATION for Python $PY_NUM as $PACK_TYPE."
 
-# Python 2
-if (( ${PY_NUM:0:1} == 2 )) ; then
-    if (( ${PY_NUM:2:3} < 7 )) ; then # or version is later than 4.0.0
-        echo "Python version is insufficient, you supplied $PY_NUM when you need 2.7.  Python 2 will be removed in 4.0.0."
-        usage;
-    fi
+    # python-stomp < 5.0.0 to python-stomp, python to python3/pip3
+    # edited python-pip3 to python-pip
+    FPM_PYTHON="--depends python3 \
+        --depends python-pip3 \
+        --depends 'python-stomp' \
+        --depends python-ldap \
+        --depends libssl-dev \
+        --depends libsasl2-dev \
+        --depends openssl "
+
+elif [[ ${PY_NUM:0:1} == "2" ]]; then
     echo "Building $VERSION iteration $ITERATION for Python $PY_NUM as $PACK_TYPE."
 
     FPM_PYTHON="--depends python2.7 \
@@ -133,61 +129,29 @@ if (( ${PY_NUM:0:1} == 2 )) ; then
         --depends python-ldap \
         --depends libssl-dev \
         --depends libsasl2-dev \
-        --depends openssl " \
-
-# Python 3
-elif (( ${PY_NUM:0:1} == 3 )) ; then
-    if (( ${PY_NUM:2:3} < 6 )) ; then
-        echo "Python version is insufficient, you supplied $PY_NUM when you need above 3.5."
-        usage;
-    fi
-    echo "Building $VERSION iteration $ITERATION for Python $PY_NUM as $PACK_TYPE."
-
-    # python-stomp < 5.0.0 to python-stomp
-    # everything else is chill
-    FPM_PYTHON="--depends python3.6 \
-        --depends python-pip3 \
-        --depends 'python-stomp' \
-        --depends python-ldap \
-        --depends libssl-dev \
-        --depends libsasl2-dev \
-        --depends openssl " \
-
+        --depends openssl " 
 fi
 
-if [ "$PACK_TYPE" == "deb" ]; then 
-    FPM_PYTHON="${FPM_PYTHON} --python-bin ${BIN_DIR}"
-fi
-
-# FPM Version Specific End
-# Change pythoninstall lib?
-# is it the darned changelog?  Changelog source dir may be completely off.s
-# Place changelog in specs.
-
-
+# python-bin from python-install-bin
 PACKAGE_VERSION="--$PACK_TYPE-changelog $SOURCE_DIR/ssm-$VERSION-$ITERATION/CHANGELOG \
-    --python-install-bin /usr/bin \
+    --python-bin /usr/bin/$PY_VERSION \
     --python-install-lib $PYTHON_ROOT_DIR$LIB_EXTENSION \
     --exclude *.pyc \
     --package $BUILD_DIR \
     $SOURCE_DIR/ssm-$VERSION-$ITERATION/setup.py"
 
-
-# Spaces betwixt verbose and package_version for --rpm-changelog, space here command not found renders package_version as sep command
-# probably bash string handling issue, add handled string
 BUILD_PACKAGE_COMMAND=${FPM_CORE}${FPM_PYTHON}${VERBOSE}${PACKAGE_VERSION}
-echo $BUILD_PACKAGE_COMMAND
-eval $BUILD_PACKAGE_COMMAND
-
+echo "$BUILD_PACKAGE_COMMAND"
+eval "$BUILD_PACKAGE_COMMAND"
 
 fpm -s pleaserun -t $PACK_TYPE \
-    -n apel-ssm-service \
-    -v $VERSION \
-    --iteration $ITERATION \
-    -m "Apel Administrators <apel-admins@stfc.ac.uk>" \
-    --description "Secure Stomp Messenger (SSM) Service Daemon files." \
-    --architecture all \
-    --no-auto-depends \
-    --depends apel-ssm \
-    --package $BUILD_DIR \
-    /usr/bin/ssmreceive
+-n apel-ssm-service \
+-v $VERSION \
+--iteration $ITERATION \
+-m "Apel Administrators <apel-admins@stfc.ac.uk>" \
+--description "Secure Stomp Messenger (SSM) Service Daemon files." \
+--architecture all \
+--no-auto-depends \
+--depends apel-ssm \
+--package $BUILD_DIR \
+/usr/bin/ssmreceive

--- a/scripts/ssm-build.sh
+++ b/scripts/ssm-build.sh
@@ -93,7 +93,7 @@ rm -rf $BUILD_DIR/*
 
 # Get and extract the source
 TAR_FILE=${VERSION}-${ITERATION}.tar.gz
-TAR_URL=https://github.com/apel/ssm/archive/$TAR_FILE
+TAR_URL=https://github.com/RedProkofiev/ssm/archive/$TAR_FILE
 wget --no-check-certificate $TAR_URL -O $TAR_FILE
 tar xvf $TAR_FILE -C $SOURCE_DIR
 rm -f $TAR_FILE
@@ -157,7 +157,7 @@ fi
 # Place changelog in specs.
 
 
-FPM_VERSION="--$PACK_TYPE-changelog $SOURCE_DIR/ssm-$VERSION-$ITERATION/CHANGELOG \
+PACKAGE_VERSION="--$PACK_TYPE-changelog $SOURCE_DIR/ssm-$VERSION-$ITERATION/CHANGELOG \
     --python-install-bin /usr/bin \
     --python-install-lib $PYTHON_ROOT_DIR$LIB_EXTENSION \
     --exclude *.pyc \
@@ -165,11 +165,11 @@ FPM_VERSION="--$PACK_TYPE-changelog $SOURCE_DIR/ssm-$VERSION-$ITERATION/CHANGELO
     $SOURCE_DIR/ssm-$VERSION-$ITERATION/setup.py"
 
 
-# Spaces betwixt verbose and FPM_VERSION for --rpm-changelog, space here command not found renders fpm_version as sep command
+# Spaces betwixt verbose and package_version for --rpm-changelog, space here command not found renders package_version as sep command
 # probably bash string handling issue, add handled string
-BUILD_PACKAGE=${FPM_CORE}${FPM_PYTHON}${VERBOSE}${FPM_VERSION}
-echo $BUILD_PACKAGE
-eval $BUILD_PACKAGE
+BUILD_PACKAGE_COMMAND=${FPM_CORE}${FPM_PYTHON}${VERBOSE}${PACKAGE_VERSION}
+echo $BUILD_PACKAGE_COMMAND
+eval $BUILD_PACKAGE_COMMAND
 
 
 # fpm -s pleaserun -t $PACK_TYPE \

--- a/scripts/ssm-build.sh
+++ b/scripts/ssm-build.sh
@@ -98,80 +98,83 @@ echo $BUILD_DIR
 # tar xvf $TAR_FILE -C $SOURCE_DIR
 # rm -f $TAR_FILE
 
-# Get specific python version
-# Main distinction is 2 vs 3 but also check for 3.5 or under or under 2.7
-
+# Get supplied Python version
 PY_VERSION=$(basename $PYTHON_ROOT_DIR)
 PY_NUM=${PY_VERSION#python}
 echo $PY_NUM
 
-# One fpm call for python 2, one for python 3
-# Check for each based on minimum versioning
-# May have to vary by debian and RPM too :/
-# add in commands?
 
-# Create two sections, tack them together, render with eval command
-# Section 1: Python Version specific
-# Section 2: RPM or DEB?
-# Eval
+# Universal FPM Call
+FPM_CORE="fpm -s python -t $PACK_TYPE \
+    -n apel-ssm \
+    -v $VERSION \
+    --iteration $ITERATION \
+    -m \"Apel Administrators <apel-admins@stfc.ac.uk>\" \
+    --description \"Secure Stomp Messenger (SSM).\" \
+    --no-auto-depends \ "
 
+
+# Python Evaluation
+# Python 2
 if (( ${PY_NUM:0:1} == 2 )) ; then
     if (( ${PY_NUM:2:3} < 7 )) ; then # or version is later than 4.0.0
         echo "Python version is insufficient, you supplied $PY_NUM when you need 2.7.  Python 2 will be removed in 4.0.0."
         usage;
     fi
-    # py2 FPM call CURRENTLY DEBIAN
-    # adapt for RPM and for generalism
-    # eval 
-
     echo "Building $VERSION iteration $ITERATION for Python $PY_NUM as $PACK_TYPE."
 
+    FPM_PYTHON="--depends python2.7 \
+        --depends python-pip \
+        --depends 'python-stomp < 5.0.0' \
+        --depends python-ldap \
+        --depends libssl-dev \
+        --depends libsasl2-dev \
+        --depends openssl \ "
 
-    fpm -s python -t deb \
-    -n apel-ssm \
-    -v $VERSION \
-    --iteration $ITERATION \
-    -m "Apel Administrators <apel-admins@stfc.ac.uk>" \
-    --description "Secure Stomp Messenger (SSM)." \
-    --no-auto-depends \
-    --depends python2.7 \
-    --depends python-pip \
-    --depends 'python-stomp < 5.0.0' \
-    --depends python-ldap \
-    --depends libssl-dev \
-    --depends libsasl2-dev \
-    --depends openssl \
-    --deb-changelog $SOURCE_DIR/ssm-$TAG/CHANGELOG \
-    --python-install-bin /usr/bin \
-    --python-install-lib $PYTHON_INSTALL_LIB \
-    --exclude *.pyc \
-    --package $BUILD_DIR \
-    $SOURCE_DIR/ssm-$TAG/setup.py
-
+# Python 3
 elif (( ${PY_NUM:0:1} == 3 )) ; then
     if (( ${PY_NUM:2:3} < 6 )) ; then
         echo "Python version is insufficient, you supplied $PY_NUM when you need above 3.5."
         usage;
     fi
-    #py3 fpm call
     echo "Building $VERSION iteration $ITERATION for Python $PY_NUM as $PACK_TYPE."
+
+    # python-stomp < 5.0.0 to python-stomp
+    # everything else is chill
+    FPM_PYTHON="--depends python3.6 \
+        --depends python-pip3 \
+        --depends 'python-stomp' \
+        --depends python-ldap \
+        --depends libssl-dev \
+        --depends libsasl2-dev \
+        --depends openssl \ "
 
 fi
 
-# Create pleaserun command
-# Section 1: RPM or DEB ?
-# Don't need to eval, just change deb
 
-eval build_package
-
-fpm -s pleaserun -t $PACK_TYPE \
-    -n apel-ssm-service \
-    -v $VERSION \
-    --iteration $ITERATION \
-    -m "Apel Administrators <apel-admins@stfc.ac.uk>" \
-    --description "Secure Stomp Messenger (SSM) Service Daemon files." \
-    --architecture all \
-    --no-auto-depends \
-    --depends apel-ssm \
+# FPM Version Specific End
+# Change pythoninstall lib?
+FPM_VERSION="--$PACK_TYPE-changelog $SOURCE_DIR/ssm-$VERSION-$ITERATION/CHANGELOG \
+    --python-install-bin /usr/bin \
+    --python-install-lib $PYTHON_ROOT_DIR$LIB_EXTENSION \
+    --exclude *.pyc \
     --package $BUILD_DIR \
-    /usr/bin/ssmreceive
+    $SOURCE_DIR/ssm-$VERSION-$ITERATION/setup.py"
+
+
+BUILD_PACKAGE=${FPM_CORE}${FPM_PYTHON}${FPM_VERSION}
+# eval $BUILD_PACKAGE
+echo $BUILD_PACKAGE
+
+
+# fpm -s pleaserun -t $PACK_TYPE \
+#     -n apel-ssm-service \
+#     -v $VERSION \
+#     --iteration $ITERATION \
+#     -m "Apel Administrators <apel-admins@stfc.ac.uk>" \
+#     --description "Secure Stomp Messenger (SSM) Service Daemon files." \
+#     --architecture all \
+#     --no-auto-depends \
+#     --depends apel-ssm \
+#     --package $BUILD_DIR \
+#     /usr/bin/ssmreceive

--- a/scripts/ssm-build.sh
+++ b/scripts/ssm-build.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+# Apel-SSM Build Script 2.0: FPM edition
+# Adapted from the Debian only build script, now with RPM!
+# @Author: Nicholas Whyatt (RedProkofiev@github.com)
+
+set -e
+
+usage() { 
+    echo "Usage: $0 (deb | rpm) <version> <iteration> <python_root_dir> [options]"
+    echo -e "Build script for Apel-SSM.\n"
+    echo "  -h                    Displays help."
+    echo "  -s <source_dir>       Directory of source files.  Defaults to /debbuild/source or SOME RPM DIR." 
+    echo -e "  -b <build_dir>        Directory of build files.  Defaults to /debbuild/build or SOME RPM DIR.\n" 1>&2;
+    exit 1; 
+}
+
+# cheap python hack!
+# if ! python3 -c 'import sys; assert sys.version_info >= (3,6)' > /dev/null; then
+#     export PYTHON_VERSION=`python -c 'import sys; version=sys.version_info[:3]; print("{0}.{1}".format(*version))'
+# elif ! python2 -c 'import sys; assert sys.version_info >= (3,6)' > /dev/null; then
+
+SOURCE_ASSIGNED=0
+BUILD_ASSIGNED=0
+
+# Configurable options
+while getopts ":hs:b:" o; do
+    case "${o}" in
+        h)  echo "SSM Help"
+            usage;
+            ;;
+        s)  s=${OPTARG}
+            SOURCE_DIR=$s
+            SOURCE_ASSIGNED=1
+            ;;
+        b)  b=${OPTARG}
+            BUILD_DIR=$b
+            BUILD_ASSIGNED=1
+            ;;
+        *)  usage;
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
+# Check how any arguments there are
+if [ "$#" -ne 4 ]; then
+    echo "Expected 4 arguments, $# given."
+    usage;
+fi
+
+PACK_TYPE=$1
+VERSION=$2
+ITERATION=$3
+PYTHON_ROOT_DIR=$4 # i.e. /usr/lib/python3.6
+
+# TODO: Replace rpm directories with their sensible equivalents
+# It ain't pretty, but it is readable and it gets the job done
+# LIB_EXTENSION is the install dir for python lib files, and is system dependent
+if [[ "$PACK_TYPE" = "deb" ]]; then 
+    LIB_EXTENSION="/dist-packages"
+    if [[ "$SOURCE_ASSIGNED" = 0 ]]; then
+        SOURCE_DIR=~/debbuild/source
+    fi
+    if [[ "$BUILD_ASSIGNED" = 0 ]]; then
+        BUILD_DIR=~/debbuild/build
+    fi
+elif [[ "$PACK_TYPE" = "rpm" ]]; then
+    LIB_EXTENSION="/site-packages"
+    if [[ "$SOURCE_ASSIGNED" = 0 ]]; then
+        SOURCE_DIR=~/something/rpm
+    fi
+    if [[ "$BUILD_ASSIGNED" = 0 ]]; then
+        BUILD_DIR=~/somethingalso/rpm
+    fi
+else # If package type is neither deb nor rpm, show an error message and exit
+    echo "$0 currently only supports 'deb' and 'rpm' packages."
+    usage;
+fi
+
+# Testing
+echo $LIB_EXTENSION
+echo $SOURCE_DIR
+echo $BUILD_DIR
+
+# # Create SSM and DEB dir (if not present)
+# mkdir -p $SOURCE_DIR
+# mkdir -p $BUILD_DIR
+
+# # Clean up any previous build
+# rm -rf $SOURCE_DIR/*
+# rm -rf $BUILD_DIR/*
+
+# # Get and extract the source
+# TAR_FILE=${VERSION}-${ITERATION}.tar.gz
+# TAR_URL=https://github.com/apel/ssm/archive/$TAR_FILE
+# wget --no-check-certificate $TAR_URL -O $TAR_FILE
+# tar xvf $TAR_FILE -C $SOURCE_DIR
+# rm -f $TAR_FILE
+
+# Get specific python version
+# Main distinction is 2 vs 3 but also check for 3.5 or under or under 2.7
+
+PY_VERSION=$(basename $PYTHON_ROOT_DIR)
+PY_NUM=${PY_VERSION#python}
+echo $PY_NUM

--- a/setup.py
+++ b/setup.py
@@ -51,11 +51,14 @@ def main():
           download_url='https://github.com/apel/ssm/releases',
           license='Apache License, Version 2.0',
           install_requires=[
-              'stomp.py<5.0.0', 'python-ldap<3.4.0', 'setuptools',
+              'stomp.py<5.0.0',
+              'python-ldap<3.4.0',
+              'setuptools',
+              'PyOpenSSL',
           ],
           extras_require={
-              'AMS': ['argo-ams-library'],
-              'daemon': ['python-daemon<=2.3.0'],
+              'AMS': ['argo-ams-library', 'certifi<2020.4.5.2', ],
+              'daemon': ['python-daemon<=2.3.0', ],
               'dirq': ['dirq'],
           },
           packages=find_packages(exclude=['bin', 'test']),

--- a/setup.py
+++ b/setup.py
@@ -51,10 +51,11 @@ def main():
           download_url='https://github.com/apel/ssm/releases',
           license='Apache License, Version 2.0',
           install_requires=[
+              'cryptography==3.3.0',
               'stomp.py<5.0.0',
               'python-ldap<3.4.0',
               'setuptools',
-              'PyOpenSSL',
+              'pyopenssl<=21.0.0',
           ],
           extras_require={
               'AMS': ['argo-ams-library', 'certifi<2020.4.5.2', ],


### PR DESCRIPTION
Resolves #123 
Resolves GT-253

This PR adds a build script that supersedes ```ssm-build-rpm.sh``` and ```ssm-build-deb.sh``` by adapting the FPM calls made in the original Debian script and adding configurable parameters.  It works with Python 2.7 and >= 3.6, and requires FPM 1.14.2 and a version of Ruby at or above 2.7, as well as specifically Setuptools==51.3.3.  It allows a version to be specified to pull from the repository and be setup.

Usage: ```./ssm-build-dual.sh [options] (deb | rpm) <version> <iteration> <python_root_dir>```

Currently, this should work for all future versions and all the past RPM versions: Debian, it doesn't work for before the coming 3.4.0 update due to CHANGELOG having a title.