### PR TITLE
Update comments and options in config files

### DIFF
--- a/conf/receiver.cfg
+++ b/conf/receiver.cfg
@@ -9,7 +9,7 @@ protocol: AMS
 #bdii: ldap://lcg-bdii.cern.ch:2170
 #network: PROD
 # Alternatively, 'host' and 'port' can be set manually (with 'bdii' and
-# 'network' commented out). This option MUST be used for AMS.
+# 'network' commented out). The 'host' option MUST be used for AMS.
 host: msg-devel.argo.grnet.gr
 #host: msg.argo.grnet.gr
 #port:
@@ -29,7 +29,7 @@ check_crls: false
 ams_project: accounting
 
 # Destination to which SSM will listen.
-destination: ssm2test
+destination:
 
 # Only use direct token auth with AMS if you've been provided with a token to use.
 #token:

--- a/conf/receiver.cfg
+++ b/conf/receiver.cfg
@@ -1,16 +1,17 @@
 [receiver]
 # Either 'STOMP' for STOMP message brokers or 'AMS' for Argo Messaging Service
-protocol: STOMP
+protocol: AMS
 
 [broker]
 
 # The SSM will query a BDII to find brokers available.  These details are for the
 # EGI production broker network
-bdii: ldap://lcg-bdii.cern.ch:2170
-network: PROD
+#bdii: ldap://lcg-bdii.cern.ch:2170
+#network: PROD
 # Alternatively, 'host' and 'port' can be set manually (with 'bdii' and
 # 'network' commented out). This option MUST be used for AMS.
-#host:
+host: msg-devel.argo.grnet.gr
+#host: msg.argo.grnet.gr
 #port:
 
 # broker authentication.  If use_ssl is set, the certificates configured
@@ -25,10 +26,13 @@ check_crls: false
 
 [messaging]
 # If using AMS this is the project that SSM will connect to. Ignored for STOMP.
-ams_project:
+ams_project: accounting
 
 # Destination to which SSM will listen.
-destination: /queue/ssm2test
+destination: ssm2test
+
+# Only use direct token auth with AMS if you've been provided with a token to use.
+#token:
 
 # Accepted messages will be written to <path>/incoming
 # Rejected messages will be written to <path>/reject
@@ -36,6 +40,8 @@ path: /var/spool/apel
 
 [logging]
 logfile: /var/log/apel/ssmreceive.log
+# Available logging levels:
+# DEBUG, INFO, WARN, ERROR, CRITICAL
 level: INFO
 console: false
 

--- a/conf/sender.cfg
+++ b/conf/sender.cfg
@@ -1,16 +1,17 @@
 [sender]
 # Either 'STOMP' for STOMP message brokers or 'AMS' for Argo Messaging Service
-protocol: STOMP
+protocol: AMS
 
 [broker]
 
 # The SSM will query a BDII to find brokers available.  These details are for the
 # EGI production broker network
-bdii: ldap://lcg-bdii.cern.ch:2170
-network: PROD
+#bdii: ldap://lcg-bdii.cern.ch:2170
+#network: PROD
 # Alternatively, 'host' and 'port' may be set manually (with 'bdii' and
 # 'network' commented out). This option must be used for AMS.
-#host: msg-devel.argo.grnet.gr
+host: msg-devel.argo.grnet.gr
+#host: msg.argo.grnet.gr
 #port: 443
 
 # broker authentication.  If use_ssl is set, the certificates configured
@@ -23,7 +24,7 @@ key: /etc/grid-security/hostkey.pem
 capath: /etc/grid-security/certificates
 
 # If supplied, outgoing messages will be encrypted using this certificate.
-# May be used in addition to 'use_ssl'. If used, it must be the certificate of
+# May be used in addition to 'use_ssl'. If used, it MUST be the certificate of
 # the final server that's receiving your messages; not your own, nor the broker.
 #server_cert: /etc/grid-security/servercert.pem
 
@@ -33,6 +34,9 @@ ams_project: accounting
 
 # Queue to which SSM will send messages
 destination: gLite-APEL
+
+# Only use direct token auth with AMS if you've been provided with a token to use.
+#token:
 
 # Outgoing messages will be read and removed from this directory.
 path: /var/spool/apel/outgoing

--- a/conf/sender.cfg
+++ b/conf/sender.cfg
@@ -8,11 +8,11 @@ protocol: AMS
 # EGI production broker network
 #bdii: ldap://lcg-bdii.cern.ch:2170
 #network: PROD
-# Alternatively, 'host' and 'port' may be set manually (with 'bdii' and
-# 'network' commented out). This option must be used for AMS.
+# Alternatively, 'host' and 'port' can be set manually (with 'bdii' and
+# 'network' commented out). The 'host' option MUST be used for AMS.
 host: msg-devel.argo.grnet.gr
 #host: msg.argo.grnet.gr
-#port: 443
+#port:
 
 # broker authentication.  If use_ssl is set, the certificates configured
 # in the mandatory [certificates] section will be used.


### PR DESCRIPTION
Resolves #200 

- Set AMS as default messaging system.
- Add AMS hosts (both prod and devel) as options.
- Emphasise note about the server_cert.
- Add token as commented out option.
- Copy log level comments from sender to receiver conf.