### PR TITLE
Character vs. byte strings fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 argo-ams-library
 certifi<2020.4.5.2  # Used by AMS (via requests), 2020.4.5.2 dropped support for Python 2
 pyopenssl >=19.1.0, <=21.0.0  # 22.0.0 dropped support for Python 2
-cryptography==3.3.0  # Crypto dropped support for Python 2 after 3.3
+cryptography==3.3.2  # Crypto dropped support for Python 2 after 3.3
 stomp.py<5.0.0
 python-daemon<=2.3.0  # 2.3.1 dropped support for Python 2
 python-ldap<3.4.0  # python-ldap-3.4.0 dropped support for Python 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 argo-ams-library
 certifi<2020.4.5.2  # Used by AMS (via requests), 2020.4.5.2 dropped support for Python 2
 pyopenssl<=21.0.0  # 22.0.0 dropped support for Python 2
-cryptography==3.3.0  # Crypto dropped support for Python 2 after 3.3.  They're now on 41.X...
+cryptography==3.2.0  # Crypto dropped support for Python 2 after 3.3
 stomp.py<5.0.0
 python-daemon<=2.3.0  # 2.3.1 dropped support for Python 2
 python-ldap<3.4.0  # python-ldap-3.4.0 dropped support for Python 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@
 
 argo-ams-library
 certifi<2020.4.5.2  # Used by AMS (via requests), 2020.4.5.2 dropped support for Python 2
-pyopenssl<=21.0.0  # 22.0.0 dropped support for Python 2
-cryptography==3.2.0  # Crypto dropped support for Python 2 after 3.3
+pyopenssl >=19.1.0, <=21.0.0  # 22.0.0 dropped support for Python 2
+cryptography==3.3.0  # Crypto dropped support for Python 2 after 3.3
 stomp.py<5.0.0
 python-daemon<=2.3.0  # 2.3.1 dropped support for Python 2
 python-ldap<3.4.0  # python-ldap-3.4.0 dropped support for Python 2

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ def main():
           download_url='https://github.com/apel/ssm/releases',
           license='Apache License, Version 2.0',
           install_requires=[
-              'cryptography==3.3.0',
+              'cryptography==3.2.0',
               'stomp.py<5.0.0',
               'python-ldap<3.4.0',
               'setuptools',

--- a/setup.py
+++ b/setup.py
@@ -51,11 +51,11 @@ def main():
           download_url='https://github.com/apel/ssm/releases',
           license='Apache License, Version 2.0',
           install_requires=[
-              'cryptography==3.2.0',
+              'cryptography==3.3.0',
               'stomp.py<5.0.0',
               'python-ldap<3.4.0',
               'setuptools',
-              'pyopenssl<=21.0.0',
+              'pyopenssl >=19.1.0, <=21.0.0',
           ],
           extras_require={
               'AMS': ['argo-ams-library', 'certifi<2020.4.5.2', ],

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ def main():
           download_url='https://github.com/apel/ssm/releases',
           license='Apache License, Version 2.0',
           install_requires=[
-              'cryptography==3.3.0',
+              'cryptography==3.3.2',
               'stomp.py<5.0.0',
               'python-ldap<3.4.0',
               'setuptools',

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -318,6 +318,13 @@ class Ssm2(stomp.ConnectionListener):
 
     def _save_msg_to_queue(self, body, empaid):
         """Extract message contents and add to the accept or reject queue."""
+        try:
+            # if not bytes will fail with "'str' obj has no attribute decode"
+            body = body.decode('utf-8')
+        except (AttributeError):
+            # Message type is something string related
+            pass
+
         extracted_msg, signer, err_msg = self._handle_msg(body)
         try:
             # If the message is empty or the error message is not empty
@@ -332,7 +339,6 @@ class Ssm2(stomp.ConnectionListener):
                     body = extracted_msg
 
                 log.warning("Message rejected: %s", err_msg)
-
                 name = self._rejectq.add({'body': body,
                                           'signer': signer,
                                           'empaid': empaid,

--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -318,12 +318,8 @@ class Ssm2(stomp.ConnectionListener):
 
     def _save_msg_to_queue(self, body, empaid):
         """Extract message contents and add to the accept or reject queue."""
-        try:
-            # if not bytes will fail with "'str' obj has no attribute decode"
-            body = body.decode('utf-8')
-        except (AttributeError):
-            # Message type is something string related
-            pass
+        if isinstance(body, bytes):
+            body = body.decode('ascii')
 
         extracted_msg, signer, err_msg = self._handle_msg(body)
         try:
@@ -485,6 +481,8 @@ class Ssm2(stomp.ConnectionListener):
                 continue
 
             text = self._outq.get(msgid)
+            if isinstance(text, bytes):
+                text = text.decode('ascii')
 
             if self._protocol == Ssm2.STOMP_MESSAGING:
                 # Then we are sending to a STOMP message broker.

--- a/test/test_ssm.py
+++ b/test/test_ssm.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from __future__ import print_function
 
 import os
@@ -93,15 +92,6 @@ class TestSsm(unittest.TestCase):
         test_ssm.on_message({'empa-id': 'ping'}, 'body')
         # Check that msg with ID and no real content doesn't raise exception.
         test_ssm.on_message({'empa-id': '012345'}, 'body')
-
-    def test_str_bytes_outgoing(self):
-        """Test to ensure that outgoing messages are converted from Bytes to Str"""
-        test_ssm = Ssm2(self._brokers, self._msgdir, TEST_CERT_FILE,
-                        self._key_path, dest=self._dest, listen=self._listen)
-
-        message = "Appelle Hippocampéléphantocamélos"
-        byte_message = message.encode()
-        test_ssm.on_message({'empa-id': '012345'}, byte_message)
 
     def test_init_expired_cert(self):
         """Test right exception is thrown creating an SSM with expired cert."""

--- a/test/test_ssm.py
+++ b/test/test_ssm.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import print_function
 
 import os
@@ -92,6 +93,15 @@ class TestSsm(unittest.TestCase):
         test_ssm.on_message({'empa-id': 'ping'}, 'body')
         # Check that msg with ID and no real content doesn't raise exception.
         test_ssm.on_message({'empa-id': '012345'}, 'body')
+
+    def test_str_bytes_outgoing(self):
+        """Test to ensure that outgoing messages are converted from Bytes to Str"""
+        test_ssm = Ssm2(self._brokers, self._msgdir, TEST_CERT_FILE,
+                        self._key_path, dest=self._dest, listen=self._listen)
+
+        message = "Appelle Hippocampéléphantocamélos"
+        byte_message = message.encode()
+        test_ssm.on_message({'empa-id': '012345'}, byte_message)
 
     def test_init_expired_cert(self):
         """Test right exception is thrown creating an SSM with expired cert."""


### PR DESCRIPTION
Resolves #146 
Resolves #209 

Note that this is a conservative fix and does not add Unicode support so that the behaviour matches between Python 2 and 3.

Unicode support is tracked in #299.

Tested manually between Python 2 and 3, sending and receiving for each, and using `dirq` and `directory` sending.