### PR TITLE
Changed the unexpected log.error to use log.exception

### DIFF
--- a/ssm/agents.py
+++ b/ssm/agents.py
@@ -248,8 +248,7 @@ def run_sender(protocol, brokers, project, token, cp, log):
         log.error('SSM failed to complete successfully: %s', e)
     except Exception as e:
         print('SSM failed to complete successfully.  See log file for details.')
-        log.error('Unexpected exception in SSM: %s', e)
-        log.error('Exception type: %s', e.__class__)
+        log.exception('Unexpected exception in SSM. See traceback below.')
         sender_failed = True
     else:
         sender_failed = False
@@ -351,8 +350,7 @@ def run_receiver(protocol, brokers, project, token, cp, log, dn_file):
         dc.close()
         receiver_failed = True
     except Exception as e:
-        log.error('Unexpected exception: %s', e)
-        log.error('Exception type: %s', e.__class__)
+        log.exception('Unexpected exception in SSM. See traceback below.')
         log.error('The SSM will exit.')
         ssm.shutdown()
         dc.close()


### PR DESCRIPTION
Resolves #295 

this traces back the error to the line in the code


Before:

```
2024-04-04 15:43:27,858 - ssmsend - INFO - ========================================
2024-04-04 15:43:27,858 - ssmsend - INFO - Starting sending SSM version 3.4.0.
2024-04-04 15:43:27,858 - ssmsend - INFO - Setting up SSM with protocol: AMS
SSM failed to complete successfully.  See log file for details.
2024-04-04 15:43:27,858 - ssmsend - ERROR - Unexpected exception in SSM: msg
2024-04-04 15:43:27,858 - ssmsend - ERROR - Exception type: <class 'ValueError'>
2024-04-04 15:43:27,858 - ssmsend - INFO - SSM has shut down.
2024-04-04 15:43:27,858 - ssmsend - INFO - ========================================
```

After:

```
2024-04-04 15:44:13,693 - ssmsend - INFO - ========================================
2024-04-04 15:44:13,693 - ssmsend - INFO - Starting sending SSM version 3.4.0.
2024-04-04 15:44:13,693 - ssmsend - INFO - Setting up SSM with protocol: AMS
SSM failed to complete successfully.  See log file for details.
2024-04-04 15:44:13,693 - ssmsend - ERROR - Unexpected exception in SSM. See traceback below.
Traceback (most recent call last):
  File "~/DCIG/ssm/ssm/agents.py", line 192, in run_sender
    raise ValueError("msg")
ValueError: msg
2024-04-04 15:44:13,693 - ssmsend - INFO - SSM has shut down.
2024-04-04 15:44:13,693 - ssmsend - INFO - ========================================
```