### PR TITLE
Replaced the Popen commands in check_cert_key to use OpenSSL

### DIFF
--- a/ssm/crypto.py
+++ b/ssm/crypto.py
@@ -72,13 +72,13 @@ def check_cert_key(certpath, keypath):
         public_key_bytes = OpenSSL.crypto.dump_publickey(
             OpenSSL.crypto.FILETYPE_PEM, crypto_public_key
         )
-        
+
         certificate_public_key = public_key_bytes.decode("utf-8")
 
     except Exception as error:
         log.error(error)
         return False
-    
+
     try:
         private_key = OpenSSL.crypto.load_privatekey(
             OpenSSL.crypto.FILETYPE_PEM, key
@@ -86,14 +86,13 @@ def check_cert_key(certpath, keypath):
         public_key_bytes = OpenSSL.crypto.dump_publickey(
             OpenSSL.crypto.FILETYPE_PEM, private_key
         )
-        
+
         private_public_key = public_key_bytes.decode("utf-8")
 
     except Exception as error:
         log.error(error)
         return False
-    
-    
+
     return certificate_public_key.strip() == private_public_key.strip()
 
 def sign(text, certpath, keypath):

--- a/ssm/crypto.py
+++ b/ssm/crypto.py
@@ -69,28 +69,24 @@ def check_cert_key(certpath, keypath):
             OpenSSL.crypto.FILETYPE_PEM, cert
         )
         crypto_public_key = certificate.get_pubkey()
-        public_key_bytes = OpenSSL.crypto.dump_publickey(
+        certificate_public_key = OpenSSL.crypto.dump_publickey(
             OpenSSL.crypto.FILETYPE_PEM, crypto_public_key
         )
 
-        certificate_public_key = public_key_bytes.decode("utf-8")
-
-    except Exception as error:
-        log.error(error)
+    except OpenSSL.crypto.Error as error:
+        log.exception(error)
         return False
 
     try:
         private_key = OpenSSL.crypto.load_privatekey(
             OpenSSL.crypto.FILETYPE_PEM, key
         )
-        public_key_bytes = OpenSSL.crypto.dump_publickey(
+        private_public_key = OpenSSL.crypto.dump_publickey(
             OpenSSL.crypto.FILETYPE_PEM, private_key
         )
 
-        private_public_key = public_key_bytes.decode("utf-8")
-
-    except Exception as error:
-        log.error(error)
+    except OpenSSL.crypto.Error as error:
+        log.exception(error)
         return False
 
     return certificate_public_key.strip() == private_public_key.strip()

--- a/ssm/crypto.py
+++ b/ssm/crypto.py
@@ -49,10 +49,7 @@ def _from_file(filename):
 
 
 def check_cert_key(certpath, keypath):
-    """Check that a certificate and a key match.
-
-    Uses openssl directly to fetch the modulus of each, which must be the same.
-    """
+    """Check that a certificate and a key match."""
     try:
         cert = _from_file(certpath)
         key = _from_file(keypath)
@@ -74,7 +71,7 @@ def check_cert_key(certpath, keypath):
         )
 
     except OpenSSL.crypto.Error as error:
-        log.exception(error)
+        log.error(error)
         return False
 
     try:
@@ -86,7 +83,7 @@ def check_cert_key(certpath, keypath):
         )
 
     except OpenSSL.crypto.Error as error:
-        log.exception(error)
+        log.error(error)
         return False
 
     return certificate_public_key.strip() == private_public_key.strip()


### PR DESCRIPTION
Resolves #313

Solves original problem of a warning returned by Popen as an error and causing the function to return False

Improves the variable names from pubkey1 and pubkey2 to help show where the key came from