### PR TITLE
Issue with ssm rpm build in el9

### DIFF
--- a/scripts/ssm-build.sh
+++ b/scripts/ssm-build.sh
@@ -107,6 +107,7 @@ rm -f "$TAR_FILE"
 # Get supplied Python version
 PY_VERSION="$(basename "$PYTHON_ROOT_DIR")"
 PY_NUM=${PY_VERSION#python}
+OS_EXTENSION="$(uname -r | grep -o 'el[7-9]' || echo '_all')"
 
 # Universal FPM Call
 FPM_CORE="fpm -s python \
@@ -134,8 +135,6 @@ if [[ ${PY_NUM:0:1} == "3" ]]; then
         --depends libsasl2-dev \
         --depends openssl "
 
-        OS_EXTENSION="_all"
-
     # Currently builds for el8
     elif [[ "$PACK_TYPE" = "rpm" ]]; then
         FPM_PYTHON="--depends python3 \
@@ -144,8 +143,6 @@ if [[ ${PY_NUM:0:1} == "3" ]]; then
         --depends python3-ldap \
         --depends openssl \
         --depends openssl-devel "
-
-        OS_EXTENSION="el8"
     fi
 
 elif [[ ${PY_NUM:0:1} == "2" ]]; then
@@ -160,8 +157,6 @@ elif [[ ${PY_NUM:0:1} == "2" ]]; then
         --depends libsasl2-dev \
         --depends openssl "
 
-        OS_EXTENSION="_all"
-
     # el7 and below, due to yum package versions
     elif [[ "$PACK_TYPE" = "rpm" ]]; then
         FPM_PYTHON="--depends python2 \
@@ -170,8 +165,6 @@ elif [[ ${PY_NUM:0:1} == "2" ]]; then
         --depends python-ldap \
         --depends openssl \
         --depends openssl-devel "
-
-        OS_EXTENSION="el7"
     fi
 fi
 

--- a/scripts/ssm-build.sh
+++ b/scripts/ssm-build.sh
@@ -172,6 +172,7 @@ fi
 PACKAGE_VERSION="--$PACK_TYPE-changelog $SOURCE_DIR/ssm-$VERSION-$ITERATION/CHANGELOG \
     --$PACK_TYPE-dist $OS_EXTENSION \
     --python-bin /usr/bin/$PY_VERSION \
+    --python-install-bin /usr/bin \
     --python-install-lib $PYTHON_ROOT_DIR$LIB_EXTENSION \
     --exclude *.pyc \
     --package $BUILD_DIR \


### PR DESCRIPTION
[fcb58cb29e5ba0694d17c4e424885075a2b9da96] Will generate OS specific rpms with the python path targeting the specific OS.


[4d889d8b2a3cdb84a31c3c6b7385fcd099f8a465]: When we are using this `ssm-build.sh`. This commit will help to say python where to install the scripts to. Added this because it is by default installing ssmreceive and ssmsend to /usr/local/bin.


[4d889d8b2a3cdb84a31c3c6b7385fcd099f8a465] Added because `pleaserun` has `/usr/bin/ssmreceive` as the file to work with.