### PR TITLE
Update various actions versions and simplify

### DIFF
--- a/.github/workflows/build-pkgs.yml
+++ b/.github/workflows/build-pkgs.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Build RPM package
       id: rpm
-      uses: naveenrajm7/rpmbuild@v1.0.0
+      uses: naveenrajm7/rpmbuild@v1.0
       with:
         spec_file: "apel-ssm.spec"
 
@@ -51,7 +51,7 @@ jobs:
       run: rpmlint ${{ steps.rpm.outputs.rpm_dir_path }}
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v4.3.1
+      uses: actions/upload-artifact@v4.3
       with:
         name: Binary and Source RPMs
         path: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,7 +48,7 @@ jobs:
         # Build and push Docker image
         # https://github.com/docker/build-push-action
         name: Build and push Docker image
-        uses: docker/build-push-action@v5.1.0
+        uses: docker/build-push-action@v5.3
         with:
           # Only push containers to the registry on GitHub pushes,
           # not pull requests. GitHub won't let a rogue PR create a container

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -31,4 +31,4 @@ jobs:
     - name: Run unit tests
       run: coverage run --branch --source=ssm,bin -m unittest discover --buffer
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3.1.4
+      uses: codecov/codecov-action@v4.2


### PR DESCRIPTION
- Simplify versions for GitHub Actions to use major.minor and drop the .patch part so that the latest minor version is fetched and we get fewer dependabot pings.
- Update a couple of the outstanding actions that need updating.