### PR TITLE
Fix rpmlint to perform rpm checks in given location

### DIFF
--- a/scripts/ssm-build.sh
+++ b/scripts/ssm-build.sh
@@ -211,5 +211,5 @@ then
 else
     # Check for errors in SPEC and built packages
     # For instance; Given $(dirname /root/rpmb/rpmbuild/source) will output "/root/rpmb/rpmbuild".
-    rpmlint $(dirname $SOURCE_DIR)
+    rpmlint "$(dirname "$SOURCE_DIR")"
 fi

--- a/scripts/ssm-build.sh
+++ b/scripts/ssm-build.sh
@@ -210,5 +210,6 @@ then
     lintian "$BUILD_DIR"/apel-ssm-service_"${TAG}"_all.deb
 else
     # Check for errors in SPEC and built packages
-    rpmlint ~/rpmbuild
+    # For instance; Given $(dirname /root/rpmb/rpmbuild/source) will output "/root/rpmb/rpmbuild".
+    rpmlint $(dirname $SOURCE_DIR)
 fi


### PR DESCRIPTION
7952bc5

This commit will allow to run the file in home directory and perform rpmlint checks in an given pwd location(Say, when running the FPM script with -s and -b).
