### PR TITLE
Change `exit()` to `sys.exit()`

### DIFF
--- a/bin/receiver.py
+++ b/bin/receiver.py
@@ -66,7 +66,7 @@ def main():
         cp.read(options.config)
     else:
         print("Config file not found at", options.config)
-        exit(1)
+        sys.exit(1)
 
     # Check for pidfile
     pidfile = cp.get('daemon', 'pidfile')

--- a/bin/sender.py
+++ b/bin/sender.py
@@ -24,6 +24,7 @@ from ssm import __version__, LOG_BREAK
 import logging
 from optparse import OptionParser
 import os
+import sys
 
 try:
     import ConfigParser
@@ -57,7 +58,7 @@ def main():
         cp.read(options.config)
     else:
         print("Config file not found at", options.config)
-        exit(1)
+        sys.exit(1)
 
     ssm.agents.logging_helper(cp)
 


### PR DESCRIPTION
The `exit()` function is from site.py which may not be present depending on command line options. `sys.exit` on the other hand, will be there as it is imported.