### PR TITLE
Replace optparse with argparse

### DIFF
--- a/bin/receiver.py
+++ b/bin/receiver.py
@@ -21,10 +21,10 @@ from __future__ import print_function
 import ssm.agents
 from ssm import __version__, LOG_BREAK
 
+from argparse import ArgumentParser
 import logging
 import os
 import sys
-from optparse import OptionParser
 
 import configparser
 
@@ -34,35 +34,41 @@ def main():
     ver = "SSM %s.%s.%s" % __version__
     default_conf_location = '/etc/apel/receiver.cfg'
     default_dns_location = '/etc/apel/dns'
-    op = OptionParser(description=__doc__, version=ver)
-    op.add_option('-c', '--config',
-                  help=('location of config file, '
-                        'default path: ' + default_conf_location),
-                  default=default_conf_location)
-    op.add_option('-l', '--log_config',
-                  help='DEPRECATED - location of logging config file (optional)',
-                  default=None)
-    op.add_option('-d', '--dn_file',
-                  help=('location of the file containing valid DNs, '
-                        'default path: ' + default_dns_location),
-                  default=default_dns_location)
+    arg_parser = ArgumentParser(description=__doc__)
 
-    options, unused_args = op.parse_args()
+    arg_parser.add_argument('-c', '--config',
+                            help='location of config file, default path: '
+                                  '%s' % default_conf_location,
+                            default=default_conf_location)
+    arg_parser.add_argument('-l', '--log_config',
+                            help='DEPRECATED - location of logging config '
+                                 'file (optional)',
+                            default=None)
+    arg_parser.add_argument('-d', '--dn_file',
+                            help='location of the file containing valid DNs, '
+                                  'default path: %s' % default_dns_location,
+                            default=default_dns_location)
+    arg_parser.add_argument('-v', '--version',
+                            action='version',
+                            version='ver: %s' % ver)
+
+    # Using the vars function to output a dict-like view rather than Namespace object.
+    options = vars(arg_parser.parse_args())
 
     # Deprecating functionality.
     old_log_config_default_path = '/etc/apel/logging.cfg'
-    if (os.path.exists(old_log_config_default_path) or options.log_config is not None):
+    if (os.path.exists(old_log_config_default_path) or options['log_config'] is not None):
         logging.warning('Separate logging config file option has been deprecated.')
 
     # Absolute file path required when refreshing dn_file, relative path resulted in an error.
-    options.dn_file = os.path.abspath(options.dn_file)
+    options['dn_file'] = os.path.abspath(options['dn_file'])
 
     # Check if config file exists using os.path.isfile function.
-    if os.path.isfile(options.config):
+    if os.path.isfile(options['config']):
         cp = configparser.ConfigParser({'use_ssl': 'true'})
-        cp.read(options.config)
+        cp.read(options['config'])
     else:
-        print("Config file not found at", options.config)
+        print("Config file not found at", options['config'])
         sys.exit(1)
 
     # Check for pidfile
@@ -85,7 +91,7 @@ def main():
     brokers, project, token = ssm.agents.get_ssm_args(protocol, cp, log)
 
     ssm.agents.run_receiver(protocol, brokers, project, token,
-                            cp, log, options.dn_file)
+                            cp, log, options['dn_file'])
 
 
 if __name__ == '__main__':

--- a/bin/receiver.py
+++ b/bin/receiver.py
@@ -41,8 +41,7 @@ def main():
                                   '%s' % default_conf_location,
                             default=default_conf_location)
     arg_parser.add_argument('-l', '--log_config',
-                            help='DEPRECATED - location of logging config '
-                                 'file (optional)',
+                            help='DEPRECATED - location of logging config file',
                             default=None)
     arg_parser.add_argument('-d', '--dn_file',
                             help='location of the file containing valid DNs, '
@@ -50,7 +49,7 @@ def main():
                             default=default_dns_location)
     arg_parser.add_argument('-v', '--version',
                             action='version',
-                            version='ver: %s' % ver)
+                            version=ver)
 
     # Using the vars function to output a dict-like view rather than Namespace object.
     options = vars(arg_parser.parse_args())

--- a/bin/sender.py
+++ b/bin/sender.py
@@ -36,16 +36,15 @@ def main():
     arg_parser = ArgumentParser(description=__doc__)
 
     arg_parser.add_argument('-c', '--config',
-                            help=('location of config file, default path: '
-                                  '%s' % default_conf_location),
+                            help='location of config file, default path: '
+                                  '%s' % default_conf_location,
                             default=default_conf_location)
     arg_parser.add_argument('-l', '--log_config',
-                            help='DEPRECATED - location of logging config'
-                                 'file (optional)',
+                            help='DEPRECATED - location of logging config file',
                             default=None)
     arg_parser.add_argument('-v', '--version',
                             action='version',
-                            version='ver: %s' % ver)
+                            version=ver)
 
     # Using the vars function to output a dict-like view rather than Namespace object.
     options = vars(arg_parser.parse_args())

--- a/bin/sender.py
+++ b/bin/sender.py
@@ -21,8 +21,8 @@ from __future__ import print_function
 import ssm.agents
 from ssm import __version__, LOG_BREAK
 
+from argparse import ArgumentParser
 import logging
-from optparse import OptionParser
 import os
 import sys
 
@@ -33,28 +33,34 @@ def main():
     """Set up connection, send all messages and quit."""
     ver = "SSM %s.%s.%s" % __version__
     default_conf_location = '/etc/apel/sender.cfg'
-    op = OptionParser(description=__doc__, version=ver)
-    op.add_option('-c', '--config',
-                  help=('location of config file, '
-                        'default path: ' + default_conf_location),
-                  default=default_conf_location)
-    op.add_option('-l', '--log_config',
-                  help='DEPRECATED - location of logging config file (optional)',
-                  default=None)
+    arg_parser = ArgumentParser(description=__doc__)
 
-    options, unused_args = op.parse_args()
+    arg_parser.add_argument('-c', '--config',
+                            help=('location of config file, default path: '
+                                  '%s' % default_conf_location),
+                            default=default_conf_location)
+    arg_parser.add_argument('-l', '--log_config',
+                            help='DEPRECATED - location of logging config'
+                                 'file (optional)',
+                            default=None)
+    arg_parser.add_argument('-v', '--version',
+                            action='version',
+                            version='ver: %s' % ver)
+
+    # Using the vars function to output a dict-like view rather than Namespace object.
+    options = vars(arg_parser.parse_args())
 
     # Deprecating functionality.
     old_log_config_default_path = '/etc/apel/logging.cfg'
-    if (os.path.exists(old_log_config_default_path) or options.log_config is not None):
+    if (os.path.exists(old_log_config_default_path) or options['log_config'] is not None):
         logging.warning('Separate logging config file option has been deprecated.')
 
     # Check if config file exists using os.path.isfile function.
-    if os.path.isfile(options.config):
+    if os.path.isfile(options['config']):
         cp = configparser.ConfigParser({'use_ssl': 'true'})
-        cp.read(options.config)
+        cp.read(options['config'])
     else:
-        print("Config file not found at", options.config)
+        print("Config file not found at", options['config'])
         sys.exit(1)
 
     ssm.agents.logging_helper(cp)


### PR DESCRIPTION
Optparse is deprecated - no longer developed. Mostly a like-for-like replacement, but we use vars on the argparse object to output the values in a similar way to optparse.

The old version option on the constructor is unavailable, and so it has been replaced by adding an argument with the 'version' action.

Resolves #275
Resolves GT-540