### PR TITLE
Update build and deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 
 Secure STOMP Messenger (SSM) is designed to simply send messages
 using the [STOMP protocol](http://stomp.github.io/) or via the ARGO Messaging Service (AMS).
-Messages are signed and may be encrypted during transit.
+Messages are signed and may additionally be encrypted during transit.
 Persistent queues should be used to guarantee delivery.
 
-SSM is written in Python. Packages are available for RHEL 7, and Ubuntu Trusty.
+SSM is written in Python 3. Packages are available for EL 8 and 9, and Ubuntu.
 
 For more information about SSM, see the [EGI wiki](https://wiki.egi.eu/wiki/APEL/SSM).
 
@@ -31,8 +31,7 @@ the RPM for your version of SL, which is available on this page:
 http://fedoraproject.org/wiki/EPEL
 You will also need to have the OpenSSL library installed. Other prerequisites are listed below.
 
-The Python STOMP library (N.B. versions between 3.1.1 (inclusive) and 5.0.0
-(exclusive) are currently supported)
+The Python STOMP library
 * `yum install stomppy`
 
 The Python AMS library. This is only required if you want to use AMS. See here for details on obtaining an RPM: https://github.com/ARGOeu/argo-ams-library/
@@ -96,7 +95,7 @@ Install any missing system packages needed for the SSM:
 * `apt-get -f install`
 
 Install any missing Python requirements that don't have system packages:
-* `pip install "stomp.py<5.0.0" dirq`
+* `pip install stomp.py dirq`
 
 If you wish to run the SSM as a receiver, you will also need to install the python-daemon system package:
 * `apt-get install python-daemon`

--- a/apel-ssm.spec
+++ b/apel-ssm.spec
@@ -1,3 +1,5 @@
+%define __python /usr/bin/python3
+
 # Conditionally define python_sitelib
 %if ! (0%{?fedora} > 12 || 0%{?rhel} > 5)
 %{!?python_sitelib: %global python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
@@ -21,7 +23,7 @@ BuildArch:      noarch
 BuildRequires:  python-devel
 %endif
 
-Requires:       stomppy < 5.0.0, python-setuptools, openssl
+Requires:       stomppy < 8.1.1, python-setuptools, openssl
 Requires(pre):  shadow-utils
 
 %define ssmconf %_sysconfdir/apel

--- a/scripts/ssm-build.sh
+++ b/scripts/ssm-build.sh
@@ -67,7 +67,7 @@ fi
 PACK_TYPE=$1
 VERSION=$2
 ITERATION=$3
-PYTHON_ROOT_DIR=$4 # i.e. /usr/lib/python3.6
+PYTHON_ROOT_DIR=$4  # i.e. /usr/lib/python3.6
 
 # Alter library, build and source directories depending on the package
 if [[ "$PACK_TYPE" = "deb" ]]; then
@@ -86,7 +86,7 @@ elif [[ "$PACK_TYPE" = "rpm" ]]; then
     if [[ "$BUILD_ASSIGNED" = 0 ]]; then
         BUILD_DIR=~/rpmbuild/BUILD
     fi
-else # If package type is neither deb nor rpm, show an error message and exit
+else  # If package type is neither deb nor rpm, show an error message and exit
     echo "$0 currently only supports 'deb' and 'rpm' packages."
     usage;
 fi
@@ -125,9 +125,6 @@ FPM_CORE="fpm -s python \
 # Simple Python filter for version specific FPM
 if [[ ${PY_NUM:0:1} == "3" ]]; then
     echo "Building $VERSION iteration $ITERATION for Python $PY_NUM as $PACK_TYPE."
-    # python-stomp < 5.0.0 to python-stomp, python to python3/pip3
-    # edited python-pip3 to python-pip
-    # slight spelling inconsistencites betwixt OS's
 
     if [[ "$PACK_TYPE" = "deb" ]]; then
         FPM_PYTHON="--depends python3 \
@@ -149,30 +146,6 @@ if [[ ${PY_NUM:0:1} == "3" ]]; then
         --depends openssl \
         --depends openssl-devel "
     fi
-
-elif [[ ${PY_NUM:0:1} == "2" ]]; then
-    echo "Building $VERSION iteration $ITERATION for Python $PY_NUM as $PACK_TYPE."
-
-    if [[ "$PACK_TYPE" = "deb" ]]; then
-        FPM_PYTHON="--depends python2.7 \
-        --depends python-pip \
-        --depends 'python-stomp < 5.0.0' \
-        --depends python-cryptography \
-        --depends python-openssl \
-        --depends python-daemon \
-        --depends openssl "
-
-    # el7 and below, due to yum package versions
-    elif [[ "$PACK_TYPE" = "rpm" ]]; then
-        FPM_PYTHON="--depends python2 \
-        --depends python2-pip \
-        --depends python2-cryptography \
-        --depends python2-pyOpenSSL \
-        --depends python2-daemon \
-        --depends stomppy \
-        --depends openssl \
-        --depends openssl-devel "
-    fi
 fi
 
 # python-bin must always be specified in modern linux
@@ -189,6 +162,7 @@ PACKAGE_VERSION="--$PACK_TYPE-changelog $SOURCE_DIR/ssm-$VERSION-$ITERATION/CHAN
 BUILD_PACKAGE_COMMAND=${FPM_CORE}${FPM_PYTHON}${VERBOSE}${PACKAGE_VERSION}
 eval "$BUILD_PACKAGE_COMMAND"
 
+echo
 echo "== Generating pleaserun package =="
 
 # When installed, use pleaserun to perform system specific service setup
@@ -205,7 +179,8 @@ fpm -s pleaserun -t "$PACK_TYPE" \
 --package "$BUILD_DIR" \
 /usr/bin/ssmreceive
 
-echo "Possible Issues to Fix:"
+echo
+echo "== Possible Issues to Fix =="
 if [ "$OS_EXTENSION" == "_all" ]
 then
     # Check the resultant debs for 'lint'

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ def main():
               'pyopenssl',
           ],
           extras_require={
-              'AMS': ['argo-ams-library', ],
+              'AMS': ['argo-ams-library>=0.5.1', ],
               'daemon': ['python-daemon', ],
               'dirq': ['dirq'],
           },


### PR DESCRIPTION
This PR updates a bunch of little things now that we no longer need Python 2 support. Mainly:

- Update README
- Update SPEC file so it stays mostly in step with new build script.
- Update build script to remove Python 2 option.
- Update min AMS library version in setup.py.

Resolves #216 
Resolves #333 