### PR TITLE
Remove connection start() as deprecated

### DIFF
--- a/ssm/ssm2.py
+++ b/ssm/ssm2.py
@@ -623,7 +623,6 @@ class Ssm2(stomp.ConnectionListener):
             raise Ssm2Exception('Called start_connection() before a \
                     connection object was initialised.')
 
-        self._conn.start()
         self._conn.connect(wait=False)
 
         i = 0


### PR DESCRIPTION
This function was deprecated in stomppy 6.1.0 and is no longer required when creating connections.

Resolves #297 