### PR TITLE
Add extra dependencies for apel ssm service

### DIFF
--- a/scripts/ssm-build.sh
+++ b/scripts/ssm-build.sh
@@ -131,7 +131,6 @@ if [[ ${PY_NUM:0:1} == "3" ]]; then
         --depends python3-pip \
         --depends python3-cryptography \
         --depends python3-openssl \
-        --depends python3-daemon \
         --depends 'python3-stomp' \
         --depends openssl "
 
@@ -142,7 +141,6 @@ if [[ ${PY_NUM:0:1} == "3" ]]; then
         --depends python3-pip \
         --depends python3-cryptography \
         --depends python3-pyOpenSSL \
-        --depends python3-daemon \
         --depends openssl \
         --depends openssl-devel "
     fi
@@ -176,6 +174,7 @@ fpm -s pleaserun -t "$PACK_TYPE" \
 --architecture all \
 --no-auto-depends \
 --depends apel-ssm \
+--depends python3-daemon \
 --package "$BUILD_DIR" \
 /usr/bin/ssmreceive
 

--- a/scripts/ssm-build.sh
+++ b/scripts/ssm-build.sh
@@ -175,6 +175,7 @@ fpm -s pleaserun -t "$PACK_TYPE" \
 --no-auto-depends \
 --depends apel-ssm \
 --depends python3-daemon \
+--depends python3-dirq \
 --package "$BUILD_DIR" \
 /usr/bin/ssmreceive
 


### PR DESCRIPTION
- Remove  `python3-daemon` dependency from the base package. And, add `python3-daemon` for `apel-ssm-service` as it is required.

Resolves #371 
Resolves [GT-555]

When installing the service: Now  python3-daemon  will be installed as part of the service.
Installing:
 apel-ssm-service                noarch                3.4.1-1.el9                    @commandline                 13 k
Installing dependencies:
 python3-daemon                  noarch                2.3.2-1.el9                    epel                         46 k

[GT-555]: https://stfc.atlassian.net/browse/GT-555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ