### PR TITLE
Remove default host and tidy comments

### DIFF
--- a/conf/sender.cfg
+++ b/conf/sender.cfg
@@ -3,10 +3,11 @@
 protocol: AMS
 
 [broker]
-# 'host' and 'port' must be set manually as LDAP broker search is now removed.
-# 'port' is not used with AMS.
-host: msg-devel.argo.grnet.gr
-# port: 443
+# msg-devel.argo.grnet.gr is only for test data
+# msg.argo.grnet.gr is for production data
+host:
+# 'port' is only used for STOMP sending.
+port: 443
 
 # broker authentication.  If use_ssl is set, the certificates configured
 # in the mandatory [certificates] section will be used.


### PR DESCRIPTION
Resolves #375 in a slightly different way to suggested.

We don't want people accidentally sending to the production host, but we also don't want people to accidentally send to the devel host if not intended. So remove the default host and add the list of hosts to a comment, explaining the purpose of each.

Also uncomment the port option and clarify its usage. It does nothing for AMS sending, so might as well leave it uncommented.