### PR TITLE
Update unit test runner to Ubuntu-22.04

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -4,12 +4,12 @@ on: [push, pull_request]
 
 jobs:
   unit-test:
-    runs-on: ubuntu-20.04  # 20.04 to allow for Py 3.6
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
-        # Python versions on Rocky 8, Ubuntu 20.04, Rocky 9
-        python-version: ['3.6', '3.8', '3.9']
+        # Python versions on EL 9, Ubuntu 22.04, EL 10/Ubuntu 24.04
+        python-version: ['3.9', '3.10', '3.12']
     name: Python ${{ matrix.python-version }} test
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Unfortunately means no Python 3.6 available, but the tests aren't running at all at the moment.